### PR TITLE
Fixed the debian creation issue

### DIFF
--- a/debian/sonic-mgmt-framework.install
+++ b/debian/sonic-mgmt-framework.install
@@ -1,0 +1,3 @@
+usr/sbin/*
+rest_ui/*
+usr/models/*


### PR DESCRIPTION
Fixed the issue of deb file not containing anything in it. The issue was because of the following change that created two debian packages because of which the binaries were copied to tmp file instead of the sonic-mgmt-framework file from where the deb file is created.

https://github.com/project-arlo/sonic-mgmt-framework/commit/38b31e290bdd21be57288c5feec67dcb1beb76f8  

$(DESTDIR) path depends on the build type.

$(DESTDIR)=debian/binarypackage (single binary package)
$(DESTDIR)=debian/tmp (multiple binary package)