### PR TITLE
[mgmt-framework] Update Swagger URL to repo1.maven.org

### DIFF
--- a/models/Makefile
+++ b/models/Makefile
@@ -80,7 +80,7 @@ py-client: $(PY_CLIENT_TARGETS)
 #======================================================================
 $(CODEGEN_JAR): | $$(@D)/.
 	cd $(@D) && \
-	wget --check-certificate=quiet https://central.maven.org/maven2/io/swagger/swagger-codegen-cli/$(CODEGEN_VER)/$(@F)
+	wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/$(CODEGEN_VER)/$(@F)
 
 #======================================================================
 # Generate swagger server in GO language for Yang generated OpenAPIs


### PR DESCRIPTION
central.maven.org moved to repo1.maven.org and is https only

signed-off-by: Tamer Ahmed <tamer-ahmed@microsoft.com>