### PR TITLE
REST Server optimizations

### DIFF
--- a/debian/sonic-mgmt-framework.install
+++ b/debian/sonic-mgmt-framework.install
@@ -1,5 +1,5 @@
 build/rest_server/rest_server       usr/sbin
 build/rest_server/generate_cert     usr/sbin
-build/rest_server/dist/ui/*         rest_ui
+build/rest_server/dist/ui           etc/rest_server
 build/swagger_client_py/*_client    usr/sbin/lib/swagger_client_py
 build/cli                           usr/sbin

--- a/rest/server/handler.go
+++ b/rest/server/handler.go
@@ -69,7 +69,7 @@ func Process(w http.ResponseWriter, r *http.Request) {
 	}
 
 write_resp:
-	glog.Infof("[%s] Sending response %d, type=%s, size=%s", reqID, status, rtype, len(data))
+	glog.Infof("[%s] Sending response %d, type=%s, size=%d", reqID, status, rtype, len(data))
 	glog.V(1).Infof("[%s] data=%s", reqID, data)
 
 	// Write http response.. Following strict order should be
@@ -212,8 +212,8 @@ func trimRestconfPrefix(path string) string {
 
 // translibArgs holds arguments for invoking translib APIs.
 type translibArgs struct {
-	path   string // Translib path
-	data   []byte // payload
+	path string // Translib path
+	data []byte // payload
 }
 
 // invokeTranslib calls appropriate TransLib API for the given HTTP

--- a/rest/server/handler.go
+++ b/rest/server/handler.go
@@ -24,12 +24,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Azure/sonic-mgmt-common/translib"
-
 	"github.com/golang/glog"
-	"github.com/gorilla/mux"
 )
 
 // Process function is the common landing place for all REST requests.
@@ -38,23 +37,24 @@ import (
 func Process(w http.ResponseWriter, r *http.Request) {
 	rc, r := GetContext(r)
 	reqID := rc.ID
-	path := r.URL.Path
+	args := translibArgs{}
 
+	var err error
 	var status int
 	var data []byte
 	var rtype string
 
-	glog.Infof("[%s] %s %s; content-len=%d", reqID, r.Method, path, r.ContentLength)
-	_, body, err := getRequestBody(r, rc)
+	glog.Infof("[%s] %s %s; content-len=%d", reqID, r.Method, r.URL.Path, r.ContentLength)
+	_, args.data, err = getRequestBody(r, rc)
 	if err != nil {
 		status, data, rtype = prepareErrorResponse(err, r)
 		goto write_resp
 	}
 
-	path = getPathForTranslib(r)
-	glog.Infof("[%s] Translated path = %s", reqID, path)
+	args.path = getPathForTranslib(r, rc)
+	glog.V(1).Infof("[%s] Translated path = %s", reqID, args.path)
 
-	status, data, err = invokeTranslib(reqID, r.Method, path, body)
+	status, data, err = invokeTranslib(&args, r, rc)
 	if err != nil {
 		glog.Errorf("[%s] Translib error %T - %v", reqID, err, err)
 		status, data, rtype = prepareErrorResponse(err, r)
@@ -69,7 +69,8 @@ func Process(w http.ResponseWriter, r *http.Request) {
 	}
 
 write_resp:
-	glog.Infof("[%s] Sending response %d, type=%s, data=%s", reqID, status, rtype, data)
+	glog.Infof("[%s] Sending response %d, type=%s, size=%s", reqID, status, rtype, len(data))
+	glog.V(1).Infof("[%s] data=%s", reqID, data)
 
 	// Write http response.. Following strict order should be
 	// maintained to form proper response.
@@ -153,16 +154,13 @@ func resolveResponseContentType(data []byte, r *http.Request, rc *RequestContext
 }
 
 // getPathForTranslib converts REST URIs into GNMI paths
-func getPathForTranslib(r *http.Request) string {
-	// Return the URL path if no variables in the template..
-	vars := mux.Vars(r)
-	if len(vars) == 0 {
-		return trimRestconfPrefix(r.URL.Path)
-	}
+func getPathForTranslib(r *http.Request, rc *RequestContext) string {
+	match := getRouteMatchInfo(r)
+	path := match.path
+	vars := match.vars
 
-	path, err := mux.CurrentRoute(r).GetPathTemplate()
-	if err != nil {
-		glog.Infof("No path template for this route")
+	// Return the URL path if no variables in the template..
+	if len(vars) == 0 {
 		return trimRestconfPrefix(r.URL.Path)
 	}
 
@@ -175,14 +173,30 @@ func getPathForTranslib(r *http.Request) string {
 	path = trimRestconfPrefix(path)
 	path = strings.Replace(path, "={", "{", -1)
 	path = strings.Replace(path, "},{", "}{", -1)
+	var err error
 
 	for k, v := range vars {
+		v, err = url.PathUnescape(v)
+		if err != nil {
+			glog.Warningf("Failed to unescape path var \"%s\". err=%v", v, err)
+			v = vars[k]
+		}
+
 		restStyle := fmt.Sprintf("{%v}", k)
-		gnmiStyle := fmt.Sprintf("[%v=%v]", k, v)
+		gnmiStyle := fmt.Sprintf("[%v=%v]", rc.PMap.Get(k), escapeKeyValue(v))
 		path = strings.Replace(path, restStyle, gnmiStyle, 1)
 	}
 
 	return path
+}
+
+// escapeKeyValue function escapes a path key's value as per gNMI path
+// conventions -- prefixes '\' to ']' and '\'
+func escapeKeyValue(val string) string {
+	val = strings.Replace(val, "\\", "\\\\", -1)
+	val = strings.Replace(val, "]", "\\]", -1)
+
+	return val
 }
 
 // trimRestconfPrefix removes "/restconf/data" prefix from the path.
@@ -196,16 +210,24 @@ func trimRestconfPrefix(path string) string {
 	return path
 }
 
+// translibArgs holds arguments for invoking translib APIs.
+type translibArgs struct {
+	path   string // Translib path
+	data   []byte // payload
+}
+
 // invokeTranslib calls appropriate TransLib API for the given HTTP
 // method. Returns response status code and content.
-func invokeTranslib(reqID, method, path string, payload []byte) (int, []byte, error) {
+func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (int, []byte, error) {
 	var status = 400
 	var content []byte
 	var err error
 
-	switch method {
+	switch r.Method {
 	case "GET":
-		req := translib.GetRequest{Path: path}
+		req := translib.GetRequest{
+			Path: args.path,
+		}
 		resp, err1 := translib.Get(req)
 		if err1 == nil {
 			status = 200
@@ -217,27 +239,38 @@ func invokeTranslib(reqID, method, path string, payload []byte) (int, []byte, er
 	case "POST":
 		//TODO return 200 for operations request
 		status = 201
-		req := translib.SetRequest{Path: path, Payload: payload}
+		req := translib.SetRequest{
+			Path:    args.path,
+			Payload: args.data,
+		}
 		_, err = translib.Create(req)
 
 	case "PUT":
 		//TODO send 201 if PUT resulted in creation
 		status = 204
-		req := translib.SetRequest{Path: path, Payload: payload}
+		req := translib.SetRequest{
+			Path:    args.path,
+			Payload: args.data,
+		}
 		_, err = translib.Replace(req)
 
 	case "PATCH":
 		status = 204
-		req := translib.SetRequest{Path: path, Payload: payload}
+		req := translib.SetRequest{
+			Path:    args.path,
+			Payload: args.data,
+		}
 		_, err = translib.Update(req)
 
 	case "DELETE":
 		status = 204
-		req := translib.SetRequest{Path: path}
+		req := translib.SetRequest{
+			Path: args.path,
+		}
 		_, err = translib.Delete(req)
 
 	default:
-		glog.Errorf("[%s] Unknown method '%v'", reqID, method)
+		glog.Errorf("[%s] Unknown method '%v'", rc.ID, r.Method)
 		err = httpBadRequest("Invalid method")
 	}
 
@@ -255,4 +288,13 @@ func hostMetadataHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/xrd+xml")
 	w.Write(data.Bytes())
+}
+
+// writeErrorResponse writes HTTP error response for a error object
+func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
+	status, data, ctype := prepareErrorResponse(err, r)
+
+	w.Header().Set("Content-Type", ctype)
+	w.WriteHeader(status)
+	w.Write(data)
 }

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -22,77 +22,52 @@ package server
 import (
 	"encoding/xml"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/gorilla/mux"
 )
 
-func init() {
-	fmt.Println("+++++ init handler_test +++++")
-}
-
-var testRouter *mux.Router
+var testRouter *Router
 
 // Basic mux.Router tests
 func TestRoutes(t *testing.T) {
-	initCount := countRoutes(NewRouter())
+	AddRoute("one", "GET", "/testroute/1", newHandler(1))
+	AddRoute("two", "GET", "/testroute/2", newHandler(2))
+	AddRoute("two", "GET", "/restconf/data/testroute/3", newHandler(3))
+	AddRoute("two", "GET", "/restconf/data/testroute/4", newHandler(4))
 
-	// Add couple of test handlers
-
-	AddRoute("one", "GET", "/test/1", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(1)
-	})
-
-	AddRoute("two", "GET", "/test/2", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(2)
-	})
-
-	SetUIDirectory("/tmp/ui") // !!?
-	testRouter = NewRouter()
-	newCount := countRoutes(testRouter)
-
-	if newCount != initCount+2 {
-		t.Fatalf("Expected route count %d; found %d", initCount+2, newCount)
-	}
+	testRouter = newDefaultRouter()
 
 	// Try the test URLs and an unknown URL. The unknonw path
 	// should return 404
-	t.Run("Get1", testGet("/test/1", 1))
-	t.Run("Get2", testGet("/test/2", 2))
-	t.Run("GetUnknown", testGet("/test/unknown", 404))
+	t.Run("Get1", testGet("/testroute/1", 1))
+	t.Run("Get2", testGet("/testroute/2", 2))
+	t.Run("Get3", testGet("/restconf/data/testroute/3", 3))
+	t.Run("Get4", testGet("/restconf/data/testroute/4", 4))
+	t.Run("GetUnknown", testGet("/testroute/4", 404))
 	t.Run("Meta", testGet("/.well-known/host-meta", 200))
 
 	// Try the test URLs with authentication enabled.. This should
 	// fail the requests with 401 error. Unknown path should still
 	// return 404.
-	SetUserAuthEnable(true)
-	testRouter = NewRouter()
-	t.Run("Get1_auth", testGet("/test/1", 401))
-	t.Run("Get2_auth", testGet("/test/2", 401))
-	t.Run("GetUnknown_auth", testGet("/test/unknown", 404))
-
-	// Meta handler should not be affected by user auth
-	t.Run("Meta_auth", testGet("/.well-known/host-meta", 200))
+	testRouter.config.AuthEnable = true
+	t.Run("Get1_auth", testGet("/testroute/1", 401))
+	t.Run("Get2_auth", testGet("/testroute/2", 401))
+	t.Run("Get3", testGet("/restconf/data/testroute/3", 401))
+	t.Run("Get4", testGet("/restconf/data/testroute/4", 401))
+	t.Run("GetUnknown_auth", testGet("/testroute/4", 404))
+	t.Run("Meta_auth", testGet("/.well-known/host-meta", 401))
 
 	// Cleanup for next tests
-	SetUserAuthEnable(false)
 	testRouter = nil
 }
 
-// countRoutes counts the registered routes in a mux.Router
-// object by walking it
-func countRoutes(r *mux.Router) int {
-	var count int
-	r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		count++
-		return nil
-	})
-
-	return count
+// newHandler creates a http handler that returns given status
+func newHandler(n int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(n)
+	}
 }
 
 // Try the url and check response code
@@ -110,7 +85,7 @@ func TestMetadataHandler(t *testing.T) {
 	r := httptest.NewRequest("GET", "/.well-known/host-meta", nil)
 	w := httptest.NewRecorder()
 
-	NewRouter().ServeHTTP(w, r)
+	newDefaultRouter().ServeHTTP(w, r)
 
 	if w.Code != 200 {
 		t.Fatalf("Request failed with status %d", w.Code)
@@ -229,31 +204,98 @@ func TestPathConv(t *testing.T) {
 		"*",
 		"/test/id=NOTEMPLATE",
 		"/test/id=NOTEMPLATE"))
+
+	t.Run("empty_params", testPathConv2(
+		map[string]string{},
+		"/test/id={name}",
+		"/test/id=X",
+		"/test/id[name=X]"))
+
+	t.Run("1param", testPathConv2(
+		map[string]string{"name1": "name"},
+		"/test/id={name1}",
+		"/test/id=X",
+		"/test/id[name=X]"))
+
+	t.Run("nparams", testPathConv2(
+		map[string]string{"name1": "name", "name2": "name"},
+		"/test/id={name1}/data/ref={name2}",
+		"/test/id=X/data/ref=Y",
+		"/test/id[name=X]/data/ref[name=Y]"))
+
+	t.Run("extra_params", testPathConv2(
+		map[string]string{"name1": "name", "name2": "name"},
+		"/test/id={name1}",
+		"/test/id=X",
+		"/test/id[name=X]"))
+
+	t.Run("escaped", testPathConv(
+		"/test/interface={name}/ip={addr}",
+		"/test/interface=Ethernet%200%2f1/ip=10.0.0.1%2f24",
+		"/test/interface[name=Ethernet 0/1]/ip[addr=10.0.0.1/24]"))
+
+	t.Run("escaped2", testPathConv(
+		"/test/interface={name},{ip}",
+		"/test/interface=Eth0%2f1%5b2%5c%5d,1::1",
+		"/test/interface[name=Eth0/1[2\\\\\\]][ip=1::1]"))
+
+	t.Run("escaped+param", testPathConv2(
+		map[string]string{"name1": "name"},
+		"/test/interface={name1},{type}",
+		"/test/interface=Eth0%2f1:1,PHY",
+		"/test/interface[name=Eth0/1:1][type=PHY]"))
+
+	t.Run("rcdata_nparams", testPathConv2(
+		map[string]string{"name1": "name", "name2": "name"},
+		"/restconf/data/id={name1}/data/ref={name2}",
+		"/restconf/data/id=X/data/ref=Y",
+		"/id[name=X]/data/ref[name=Y]"))
+
+	t.Run("rcdata_escaped", testPathConv(
+		"/restconf/data/interface={name}/ip={addr}",
+		"/restconf/data/interface=Ethernet%200%2f1/ip=10.0.0.1%2f24",
+		"/interface[name=Ethernet 0/1]/ip[addr=10.0.0.1/24]"))
+
+	t.Run("rcdata_escaped2", testPathConv(
+		"/restconf/data/interface={name},{ip}",
+		"/restconf/data/interface=Eth0%2f1%5b2%5c%5d,1::1",
+		"/interface[name=Eth0/1[2\\\\\\]][ip=1::1]"))
+
+	t.Run("rcdata_escaped+param", testPathConv2(
+		map[string]string{"name1": "name"},
+		"/restconf/data/interface={name1},{type}",
+		"/restconf/data/interface=Eth0%2f1:1,PHY",
+		"/interface[name=Eth0/1:1][type=PHY]"))
+
 }
 
 // test handler to invoke getPathForTranslib and write the conveted
 // path into response. Conversion logic depends on context values
 // managed by mux router. Hence should be called from a handler.
 var pathConvHandler = func(w http.ResponseWriter, r *http.Request) {
-	// t, err := mux.CurrentRoute(r).GetPathTemplate()
-	// fmt.Printf("Patt : %v (err=%v)\n", t, err)
-	// fmt.Printf("Vars : %v\n", mux.Vars(r))
-
-	w.Write([]byte(getPathForTranslib(r)))
+	rc, r := GetContext(r)
+	w.Write([]byte(getPathForTranslib(r, rc)))
 }
 
 func testPathConv(template, path, expPath string) func(*testing.T) {
+	return testPathConv2(nil, template, path, expPath)
+}
+
+func testPathConv2(m map[string]string, template, path, expPath string) func(*testing.T) {
 	return func(t *testing.T) {
-		router := mux.NewRouter()
-		if template == "*" {
-			t.Logf("No template...")
-			router.Methods("GET").HandlerFunc(pathConvHandler)
-		} else {
-			router.HandleFunc(template, pathConvHandler)
+		router := newEmptyRouter()
+		router.addRoute(t.Name(), "GET", template, pathConvHandler)
+
+		r := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+
+		if m != nil {
+			rc, r1 := GetContext(r)
+			rc.PMap = m
+			r = r1
 		}
 
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
+		router.ServeHTTP(w, r)
 
 		convPath := w.Body.String()
 		if convPath != expPath {
@@ -520,5 +562,26 @@ func prepareRequest(t *testing.T, method, path, data string) *http.Request {
 func verifyResponse(t *testing.T, w *httptest.ResponseRecorder, expCode int) {
 	if w.Code != expCode {
 		t.Fatalf("Expecting response status %d; got %d", expCode, w.Code)
+	}
+}
+
+// newDefaultRouter creates a router instance through NewRouter function
+// with default configurations. Includes already registred routes.
+func newDefaultRouter() *Router {
+	return NewRouter(RouterConfig{})
+}
+
+// newEmptyRouter creates an empty router instance (with no routes).
+// Routes can be added through addRoute function.
+func newEmptyRouter() *Router {
+	return &Router{routes: newRouteStore()}
+}
+
+func (r *Router) addRoute(name, method, path string, h http.HandlerFunc) {
+	if path == "*" {
+		r.routes.muxRoutes.Methods(method).Handler(withMiddleware(h, name))
+	} else {
+		rr := routeRegInfo{name: name, method: method, path: path, handler: h}
+		r.routes.addRoute(&rr)
 	}
 }

--- a/rest/server/router.go
+++ b/rest/server/router.go
@@ -20,7 +20,10 @@
 package server
 
 import (
+	"flag"
 	"net/http"
+	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -29,69 +32,333 @@ import (
 )
 
 // Root directory for UI files
-var swaggerUIDir = "./ui"
-var isUserAuthEnabled = false
+var swaggerUIDir = "/etc/rest_server/ui"
 
-// SetUIDirectory functions sets directiry where Swagger UI
-// resources are maintained.
-func SetUIDirectory(directory string) {
-	swaggerUIDir = directory
+func init() {
+	flag.StringVar(&swaggerUIDir, "rest_ui", "/etc/rest_server/ui", "REST UI resources directory")
 }
 
-// SetUserAuthEnable function enables/disables the PAM based user
-// authentication for REST requests. By default user uthentication
-// is disabled. When enabled, the server expects clients to pass
-// user credentials as per HTTP Basic Autnetication method.
-func SetUserAuthEnable(val bool) {
-	isUserAuthEnabled = val
+// Router dispatches http request to corresponding handlers.
+type Router struct {
+	// config for this Router instance
+	config RouterConfig
+
+	// routes contains all registered route info
+	routes *routeStore
 }
 
-// Route registration information
-type Route struct {
-	Name    string
-	Method  string
-	Pattern string
-	Handler http.HandlerFunc
+// RouterConfig holds runtime configurations for a Router instance.
+type RouterConfig struct {
+	// AuthEnable indicates if client authentication is enabled
+	AuthEnable bool
 }
 
-// Collection of all routes
-var allRoutes []Route
+// ServeHTTP resolves and invokes the handler for http request r.
+// RESTCONF paths are served from the routeTree; rest from mux router.
+func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := cleanPath(r.URL.EscapedPath())
+	r = setContextValue(r, routerObjContextKey, router)
+
+	if isServeFromTree(path) {
+		router.serveFromTree(path, r, w)
+	} else {
+		router.routes.muxRoutes.ServeHTTP(w, r)
+	}
+}
+
+// serveFromTree finds and invokes the handler for a path from routeTree
+func (router *Router) serveFromTree(path string, r *http.Request, w http.ResponseWriter) {
+	var routeInfo routeMatchInfo
+	node := router.routes.rcRoutes.match(path, &routeInfo)
+
+	// Node not found..
+	if node == nil {
+		notFound(w, r)
+		return
+	}
+
+	handler := node.handlers[r.Method]
+
+	// Node found, but no handler for the method
+	if handler == nil {
+		notAllowed(w, r)
+		return
+	}
+
+	// Set route match info in context
+	r = setContextValue(r, routeMatchContextKey, &routeInfo)
+
+	handler.ServeHTTP(w, r)
+}
+
+// cleanPath returns the canonical path for p
+func cleanPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+
+	return path.Clean(p)
+}
+
+// isServeFromTree checks if a path will be served from routeTree.
+func isServeFromTree(path string) bool {
+	return strings.HasPrefix(path, "/restconf/")
+}
+
+// routeMatchInfo holds the matched route information in
+// request context.
+type routeMatchInfo struct {
+	path string
+	vars map[string]string
+	node *routeNode // only valid for tree based matches
+}
+
+// routeTree is the mapping of path prefix to routeNode object.
+// It holds REST API route infomation in tree format.
+type routeTree map[string]*routeNode
+
+// routeNode is the node in routeTree. Each node represents one
+// element in the path. Eg, path "/one/two={id},{name}" has 2
+// nodes - "/one" and "/two={id},{name}".
+//
+// routeNode holds handlers for current path and a routeTree
+// for child paths.
+type routeNode struct {
+	path   string   // full path from root
+	name   string   // node name
+	params []string // path params for this node, in order
+
+	handlers map[string]http.Handler // method to handler mapping
+	subpaths routeTree               // sub paths
+}
+
+// add function registers a REST API info into routeTree.
+func (t *routeTree) add(parentPrefix, path string, rr *routeRegInfo) {
+	root, next := pathSplit(path)
+	node := (*t)[root]
+	if node == nil {
+		node = newRouteNode(root, parentPrefix)
+		if node == nil {
+			glog.Errorf("Failed to parse path node '%s'", root)
+			glog.Errorf("Ignoring route %s, %s %s", rr.name, rr.method, rr.path)
+			return
+		}
+
+		(*t)[root] = node
+	}
+
+	if len(next) == 0 {
+		// target node found, register handler
+		if node.handlers == nil {
+			node.handlers = make(map[string]http.Handler)
+		}
+
+		node.handlers[rr.method] = withMiddleware(rr.handler, rr.name)
+
+	} else {
+		if node.subpaths == nil {
+			node.subpaths = make(routeTree)
+		}
+
+		node.subpaths.add(node.path, next, rr)
+	}
+}
+
+// match resolves the routeNode for a request path.
+func (t *routeTree) match(path string, m *routeMatchInfo) *routeNode {
+	var matchedNode *routeNode
+	root, next := pathSplit(path)
+	name, values := pathNameValues(root)
+	numValues := len(values)
+
+	for _, node := range *t {
+		if node.name != name || len(node.params) != numValues {
+			continue
+		}
+
+		// Node matched.. Collect variables
+		if numValues != 0 && m.vars == nil {
+			m.vars = make(map[string]string)
+		}
+		for i, p := range node.params {
+			m.vars[p] = values[i]
+		}
+
+		matchedNode = node
+		break
+	}
+
+	// No match
+	if matchedNode == nil {
+		return nil
+	}
+
+	// Full path match
+	if len(next) == 0 {
+		m.node = matchedNode
+		m.path = matchedNode.path
+		return matchedNode
+	}
+
+	// Paths matched so far.. Continue searching sub tree
+	return matchedNode.subpaths.match(next, m)
+}
+
+// pathSplit splits a path into 2 parts - root and remaining.
+// For the last node remaining part will be an empty string.
+//
+// Examples:
+// pathSplit("/one") returns ("/one", "").
+// pathSplit("/one/two/3") returns ("/one", "/two/3").
+func pathSplit(p string) (string, string) {
+	if len(p) > 1 {
+		if k := strings.Index(p[1:], "/") + 1; k > 0 {
+			return p[0:k], p[k:]
+		}
+	}
+
+	return p, "" // last node
+}
+
+// pathNameValues splits the path element name and value list.
+// Path element is expected to be in "/name[=value[,value]*]" syntax.
+//
+// Exampels:
+// pathNameValues("/xx") returns ("/xx", nil)
+// pathNameValues("/xx=") returns ("/xx", [])
+// pathNameValues("/xx=yy") returns ("/xx", ["yy"])
+// pathNameValues("/xx=yy,zz") returns ("/xx", ["yy", "zz"])
+func pathNameValues(p string) (string, []string) {
+	if k := strings.Index(p, "="); k != -1 {
+		return p[0:k], strings.Split(p[k+1:], ",")
+	}
+
+	return p, nil
+}
+
+// pathParamExpr is the regex to parse path parameter in "{xyz}" syntax.
+// Parameter should be a yang identifier as defined in YANG RFC6020; it
+// can include alphabets, digits, dot, hypen or underscore.
+var pathParamExpr = regexp.MustCompile(`{([a-zA-Z0-9_.-]+)}`)
+
+// newRouteNode creates a routeNode object for a path element p.
+func newRouteNode(p, parentPrefix string) *routeNode {
+	node := &routeNode{path: parentPrefix + p}
+	node.name, node.params = pathNameValues(p)
+
+	// remove { } around the parameter name
+	for i, param := range node.params {
+		m := pathParamExpr.FindStringSubmatch(param)
+		if len(m) != 2 { // invalid path param
+			return nil
+		}
+		node.params[i] = m[1]
+	}
+
+	return node
+}
+
+// routeRegInfo holds route registration information.
+type routeRegInfo struct {
+	name    string
+	method  string
+	path    string
+	handler http.HandlerFunc
+}
+
+// allRoutes is a collection of all routes
+var allRoutes = newRouteStore()
 
 // AddRoute appends specified routes to the routes collection.
 // Called by init functions of swagger generated router.go files.
 func AddRoute(name, method, pattern string, handler http.HandlerFunc) {
-	route := Route{
-		Name:    name,
-		Method:  strings.ToUpper(method),
-		Pattern: pattern,
-		Handler: handler,
+	rr := routeRegInfo{
+		name:    name,
+		method:  strings.ToUpper(method),
+		path:    pattern,
+		handler: handler,
 	}
 
-	allRoutes = append(allRoutes, route)
+	allRoutes.addRoute(&rr)
 }
 
-// NewRouter function returns a new http router instance. Collects
-// route information from swagger-codegen generated code and makes a
-// github.com/gorilla/mux router object.
-func NewRouter() *mux.Router {
-	router := mux.NewRouter().StrictSlash(true)
+// NewRouter creates a new http router instance for the REST server.
+// Includes all routes registered via AddRoute API as well as few
+// internal service API routes.
+// Router instance specific configurations are accepted through a
+// RouterConfig object.
+func NewRouter(config RouterConfig) *Router {
+	glog.Infof("Server has %d routes on routeTree and %d on mux router",
+		allRoutes.rcRouteCount, allRoutes.muxRouteCount)
 
-	glog.Infof("Server has %d paths", len(allRoutes))
+	// Add internal service API routes if not added already
+	allRoutes.addServiceRoutes()
 
-	// Collect swagger generated route information
-	for _, route := range allRoutes {
-		handler := withMiddleware(route.Handler, route.Name)
-
-		glog.V(2).Infof(
-			"Adding %s, %s %s",
-			route.Name, route.Method, route.Pattern)
-
-		router.
-			Methods(route.Method).
-			Path(route.Pattern).
-			Name(route.Name).
-			Handler(handler)
+	router := &Router{
+		config: config,
+		routes: allRoutes,
 	}
+
+	return router
+}
+
+// routeStore holds REST route information - which includes route name,
+// HTTP method, path and the handler function. All RESTCONF routes (path
+// starting with "/restconf") are maintained in a routeTree. Other routes
+// are maintained in a mux router.
+type routeStore struct {
+	rcRoutes     routeTree // restconf routes
+	rcRouteCount uint32    // number of restconf routes
+
+	muxRoutes     *mux.Router // non-restconf and internal routes (UI, yang)
+	muxRouteCount uint32      // number of routes in mux router
+
+	svcRoutesAdded bool // indicates if service routes have been registered
+}
+
+// newRouteStore creates an empty routeStore instance.
+func newRouteStore() *routeStore {
+	rs := new(routeStore)
+	rs.rcRoutes = make(routeTree)
+
+	r := mux.NewRouter().StrictSlash(true).UseEncodedPath()
+	r.NotFoundHandler = http.HandlerFunc(notFound)
+	r.MethodNotAllowedHandler = http.HandlerFunc(notAllowed)
+
+	rs.muxRoutes = r
+
+	return rs
+}
+
+func (rs *routeStore) addRoute(rr *routeRegInfo) {
+	glog.V(2).Infof("Adding route %s, %s %s", rr.name, rr.method, rr.path)
+
+	if isServeFromTree(rr.path) {
+		rs.rcRoutes.add("", rr.path, rr)
+		rs.rcRouteCount++
+	} else {
+		rs.addMuxRoute(rr)
+	}
+}
+
+func (rs *routeStore) addMuxRoute(rr *routeRegInfo) {
+	h := withMiddleware(rr.handler, rr.name)
+	rs.muxRoutes.Methods(rr.method).Path(rr.path).Handler(h)
+	rs.muxRouteCount++
+}
+
+// finish creates routes for all internal service API handlers in
+// mux router. Should be called after all REST API routes are added.
+func (rs *routeStore) addServiceRoutes() {
+	if rs.svcRoutesAdded {
+		return
+	}
+
+	rs.svcRoutesAdded = true
+	router := rs.muxRoutes
 
 	// Documentation and test UI
 	uiHandler := http.StripPrefix("/ui/", http.FileServer(http.Dir(swaggerUIDir)))
@@ -99,17 +366,40 @@ func NewRouter() *mux.Router {
 
 	// Redirect "/ui" to "/ui/index.html"
 	router.Methods("GET").Path("/ui").
-		Handler(http.RedirectHandler("/ui/index.html", 301))
-
-	//router.Methods("GET").Path("/model").
-	//	Handler(http.RedirectHandler("/ui/model.html", 301))
+		Handler(http.RedirectHandler("/ui/index.html", http.StatusMovedPermanently))
 
 	// Metadata discovery handler
 	metadataHandler := http.HandlerFunc(hostMetadataHandler)
 	router.Methods("GET").Path("/.well-known/host-meta").
-		Handler(loggingMiddleware(metadataHandler, "hostMetadataHandler"))
+		Handler(withMiddleware(metadataHandler, "hostMetadataHandler"))
+}
 
-	return router
+// getRouteMatchInfo returns routeMatchInfo from request context.
+func getRouteMatchInfo(r *http.Request) *routeMatchInfo {
+	m, _ := getContextValue(r, routeMatchContextKey).(*routeMatchInfo)
+	if m != nil {
+		return m
+	}
+
+	m = new(routeMatchInfo)
+
+	// Fill route info from mux "current route"
+	if curr := mux.CurrentRoute(r); curr != nil {
+		m.path, _ = curr.GetPathTemplate()
+		m.vars = mux.Vars(r)
+	}
+	if len(m.path) == 0 {
+		m.path = cleanPath(r.URL.Path)
+	}
+
+	return m
+}
+
+// getRouterConfig returns the RouterConfig from current HTTP
+// requests's context. Returns nil if the RouterConfig was not set.
+func getRouterConfig(r *http.Request) *RouterConfig {
+	rr := getContextValue(r, routerObjContextKey).(*Router)
+	return &rr.config
 }
 
 // loggingMiddleware returns a handler which times and logs the request.
@@ -132,9 +422,20 @@ func loggingMiddleware(inner http.Handler, name string) http.Handler {
 // withMiddleware function prepares the default middleware chain for
 // REST APIs.
 func withMiddleware(h http.Handler, name string) http.Handler {
-	if isUserAuthEnabled {
-		h = authMiddleware(h)
-	}
-
+	h = authMiddleware(h)
 	return loggingMiddleware(h, name)
+}
+
+// notFound responds with HTTP 404 status
+func notFound(w http.ResponseWriter, r *http.Request) {
+	glog.V(2).Infof("NOT FOUND: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+	writeErrorResponse(w, r,
+		httpError(http.StatusNotFound, "Not Found"))
+}
+
+// notAllowed responds with HTTP 405 status
+func notAllowed(w http.ResponseWriter, r *http.Request) {
+	glog.V(2).Infof("NOT ALLOWED: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+	writeErrorResponse(w, r,
+		httpError(http.StatusMethodNotAllowed, "%s Not Allowed", r.Method))
 }

--- a/tools/test/rest-server.sh
+++ b/tools/test/rest-server.sh
@@ -55,7 +55,7 @@ if [[ -z $CVL_CFG_FILE ]]; then
     fi
 fi
 
-EXTRA_ARGS="-ui $SERVER_DIR/dist/ui -logtostderr"
+EXTRA_ARGS="-rest_ui $SERVER_DIR/dist/ui -logtostderr"
 
 for V in $@; do
     case $V in


### PR DESCRIPTION
**- Why I did it**

We observed slow and non-deterministic response times from the mgmt-framework REST server. Profiling revealed hotspots in TLS handshake in go http library and regex evaluation in github.com/gorilla/mux router. This PR addresses these performance issues. It also includes few minor cleanups & fixes required for upcoming PRs.

**- How I did it**

1\) REST server used github.com/gorilla/mux router for matching the request path to registered OpenAPI path template. Mux uses linear regex based path matching, which does not scale for >10k templates. This affects REST server performance when large yangs are deployed.

Yang generated RESTCONF OpenAPI specs do not use regex path templates. Implemented a simple http request router which maintains a tree of RESTCONF path templates and matches the request using a tree search. Each element of the path template is a tree node. Example:

```
 Templates:       Tree:    A         Matched paths:
 /A/B={id}/X             /   \       /A, /A/B, /A/B=1, /A/C
 /A/B={id}/Y          B={id}  C      /A/B=2/X, /A/B=3/Y
 /A/C                 /    \
                     X      Y        Does not match: /B, /A/D
```

Request path elements are iterated left to right while traversing the tree top to bottom. Parameterized path elements are parsed as `<name>=<comma_separated_values>` format (per RESTCONF spec) and names are compared. Only parameter counts (if any) are matched. Syntax checks not done here, it will be validated by translib later.

This simple tree search significantly improves REST server performance and ensures uniform response time irrespective of number of yangs deployed. One of the examples: 68s vs 0.09s to match 1000 requests.

Non-RESTCONF paths (defined by direct OpenAPI specs) continue to get managed thru the existing mux router. RESTCONF paths are identified by the path prefix "/restconf/".

2\) Do not set TLS curve preference while initializing HTTPS server. Old code was setting preference P521,P384,P256. By default go prefers faster X25519 curve. This saved approx 42s for 1000 REST calls.

3\) Changed global auth enable flag as router instance configuration. RBAC code (coming next) will require multiple router instances with different auth modes.

4\) Handle url escaped path param values - like `/ip=10.0.0.1%2f32`. Translib path will be `/ip[10.0.0.1/32]`.

5\) Framework for custom path parameter name to yang key name mapping. Yang allows same key attribute names in parent and child lists. This results in RESTCONF paths with same parameter name at multiple levels. OpenAPI suggests unique parameter names; swagger tools do not support duplicate parameter names. Solution is to generate OpenAPI spec with unique path parameter names and generate a key mapping through OpenAPI extension schema. Key mapping contains assigned name to yang name map. REST server uses it to generate the translib path with proper yang key attribute name.

```
  list AA {                 RESTCONF path: /AA={id}/BB={id}
      key id;               OpenAPI path : /AA={id}/BB={id#2}
      list BB {             Key mappings : { "id#2": "id" }
          key id;
      }                     Request URL  : /AA=1/BB=2
  }                         Translib path: /AA[id=1]/BB[id=2]
```

This commit only includes REST server part of this solution. OpenAPI generator enhancemnets will come later.

6\) Updated go test cases for above enhancements.

7\) Changed swagger UI installation path to `/etc/rest_server/ui`. It can be overridden through command line option -rest_ui for local testing.

**- How to verify it**

Verify ACL related REST calls.
KLISH CLI
Gotest

**- Description for the changelog**

REST Server optimizations