### PR TITLE
OpenAPI spec generator enhancements and fixes

### DIFF
--- a/tools/pyang/pyang_plugins/openapi.py
+++ b/tools/pyang/pyang_plugins/openapi.py
@@ -21,13 +21,15 @@ import optparse
 import sys
 
 from pyang import plugin
-from pyang import statements
 from pyang import util
+from pyang import statements
 import pdb
 import yaml
 from collections import OrderedDict
 import copy
 import os
+import mmh3
+import json
 
 # globals
 codegenTypesToYangTypesMap = {"int8":   {"type":"integer", "format": "int32"}, 
@@ -54,7 +56,8 @@ nodeDict = OrderedDict()
 XpathToBodyTagDict = OrderedDict()
 keysToLeafRefObjSet = set()
 currentTag = None
-base_path = '/restconf/data'
+errorList = []
+warnList = []
 verbs = ["post", "put", "patch", "get", "delete"]
 responses = { # Common to all verbs
     "500": {"description": "Internal Server Error"},
@@ -64,6 +67,11 @@ responses = { # Common to all verbs
     "415": {"description": "Unsupported Media Type"},          
 }
 verb_responses = {}
+verb_responses["rpc"] = {
+    "204": {"description": "No Content"},
+    "404": {"description": "Not Found"},
+    "403": {"description": "Forbidden"},              
+}
 verb_responses["post"] = {
     "201": {"description": "Created"},
     "409": {"description": "Conflict"},
@@ -108,17 +116,27 @@ def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
     return yaml.dump(data, stream, OrderedDumper, **kwds)
 
 swaggerDict = OrderedDict()
+docJson = OrderedDict()
+docJson["config"] = OrderedDict()
+docJson["operstate"] = OrderedDict()
+docJson["operations"] = OrderedDict()
 swaggerDict["swagger"] = "2.0"
 swaggerDict["info"] = OrderedDict()
 swaggerDict["info"]["description"] = "Network management Open APIs for Broadcom's Sonic."
 swaggerDict["info"]["version"] = "1.0.0"
 swaggerDict["info"]["title"] =  "SONiC Network Management APIs"
-swaggerDict["basePath"] = base_path
 swaggerDict["schemes"] = ["https", "http"]
 swagger_tags = []
 swaggerDict["tags"] = swagger_tags
 swaggerDict["paths"] = OrderedDict()
 swaggerDict["definitions"] = OrderedDict()
+
+def resetDocJson():
+    global docJson
+    docJson = OrderedDict()
+    docJson["config"] = OrderedDict()
+    docJson["operstate"] = OrderedDict()
+    docJson["operations"] = OrderedDict()
 
 def resetSwaggerDict():
     global moduleDict
@@ -139,7 +157,6 @@ def resetSwaggerDict():
     swaggerDict["info"]["description"] = "Network management Open APIs for Sonic."
     swaggerDict["info"]["version"] = "1.0.0"
     swaggerDict["info"]["title"] =  "Sonic Network Management APIs"
-    swaggerDict["basePath"] = base_path
     swaggerDict["schemes"] = ["https", "http"]
     swagger_tags = []
     currentTag = None
@@ -147,8 +164,101 @@ def resetSwaggerDict():
     swaggerDict["paths"] = OrderedDict()
     swaggerDict["definitions"] = OrderedDict()    
 
+def documentFormatter(doc_obj, mdFh, mode):
+    if len(doc_obj) > 0:
+        if mode == "config":
+            mdFh.write("\n## %s\n\n" % ("Configuration APIs"))
+        elif mode == "operstate":
+            mdFh.write("\n## %s\n\n" % ("Operational-state APIs"))
+        elif mode == "operations":
+            mdFh.write("\n## %s\n\n" % ("Operations APIs"))
+        else:
+            pass
+
+        for uri in doc_obj:
+            mdFh.write("### %s\n" % (uri))
+            mdFh.write("#### Description\n")
+            mdFh.write("%s\n\n" % (doc_obj[uri]["description"].encode('utf8')))
+
+            if mode != "operations":
+                if len(doc_obj[uri]["parameters"]) > 0:
+                    mdFh.write("#### URI Parameters\n")
+                    mdFh.write("\n| Name | Type | Description |\n")
+                    mdFh.write("|:---:|:-----:|:-----:|\n")
+                    for param in doc_obj[uri]["parameters"]:
+                        param["description"] = param["description"].replace('\n', ' ')
+                        mdFh.write("| %s | %s  | %s  |\n" % (param["name"], param["type"], param["description"].encode('utf8')))                
+
+                for stmt in doc_obj[uri]:
+                    if stmt == "description" or stmt == "parameters":
+                        continue
+                    verb = stmt
+                    if len(doc_obj[uri][verb]["body"]) > 0:
+                        reqPrefix = "Request"
+                        if verb.lower() == "get":
+                            reqPrefix = "Response"
+                        mdFh.write("\n<details>\n<summary>%s payload for %s</summary>\n<p>" % (reqPrefix, verb.upper()))
+                        mdFh.write("\n\n```json\n")
+                        mdFh.write(json.dumps(doc_obj[uri][verb]["body"], indent=2))
+                        mdFh.write("\n```\n")
+                        mdFh.write("</p>\n</details>\n\n")
+            else:
+                if 'input' in doc_obj[uri]:
+                    mdFh.write("\n<details>\n<summary>%s payload for %s</summary>\n<p>" % ("Request", "POST"))
+                    mdFh.write("\n\n```json\n")
+                    mdFh.write(json.dumps(doc_obj[uri]["input"], indent=2))
+                    mdFh.write("\n```\n")
+                    mdFh.write("</p>\n</details>\n\n")
+                    
+                if 'output' in doc_obj[uri]:
+                    mdFh.write("\n<details>\n<summary>%s payload for %s</summary>\n<p>" % ("Response", "POST"))
+                    mdFh.write("\n\n```json\n")
+                    mdFh.write(json.dumps(doc_obj[uri]["output"], indent=2))
+                    mdFh.write("\n```\n")
+                    mdFh.write("</p>\n</details>\n\n")                
+
 def pyang_plugin_init():
     plugin.register_plugin(OpenApiPlugin())
+
+def mdGen(ctx, module):
+    if ctx.opts.with_md is None:
+        return
+    doc_config = docJson["config"]
+    if "/restconf/data/" in doc_config:
+        del(doc_config["/restconf/data/"])
+    doc_operstate = docJson["operstate"]
+    if "/restconf/data/" in doc_operstate:
+        del(doc_operstate["/restconf/data/"])        
+    doc_operations = docJson["operations"]
+    if "/restconf/data/" in doc_operations:
+        del(doc_operations["/restconf/data/"]) 
+
+    if len(doc_config) > 0 or len(doc_operstate) > 0 or len(doc_operations) > 0:
+        if ctx.opts.mdoutdir is None:
+            mdFn = ctx.opts.outdir + '/../restconf_md/' + module.i_modulename + ".md"
+        else:
+            mdFn = ctx.opts.mdoutdir + '/' + module.i_modulename + ".md"
+        mdFh = open(mdFn,'w')
+        mdFh.write("# The RESTCONF APIs for %s\n\n" % (module.i_modulename))
+        if module.search_one('description') is not None:
+            mdFh.write("%s\n\n" % (module.search_one('description').arg.encode('utf8')))
+    else:
+        # No content
+        return
+
+    # Write some headers
+    if len(doc_config) > 0:
+        mdFh.write("* [%s](#%s)\n" % ("Configuration APIs","Configuration-APIs"))
+    if len(doc_operstate) > 0:
+        mdFh.write("* [%s](#%s)\n" % ("Operational-state APIs","Operational-state-APIs"))
+    if len(doc_operations) > 0:
+        mdFh.write("* [%s](#%s)\n" % ("Operations API","Operations-API"))
+
+    documentFormatter(doc_config, mdFh, mode = "config")
+    documentFormatter(doc_operstate, mdFh, mode = "operstate")
+    documentFormatter(doc_operations, mdFh, mode = "operations")
+    mdFh.close()
+    resetDocJson()
 
 class OpenApiPlugin(plugin.PyangPlugin):
     def add_output_format(self, fmts):
@@ -160,7 +270,15 @@ class OpenApiPlugin(plugin.PyangPlugin):
             optparse.make_option("--outdir",
                                  type="string",
                                  dest="outdir",
-                                 help="Output directory for specs"),        
+                                 help="Output directory for specs"),
+            optparse.make_option("--md-outdir",
+                                 type="string",
+                                 dest="mdoutdir",
+                                 help="Output directory for markdown documents"),                                 
+            optparse.make_option("--with-md-doc",
+                                 dest="with_md",
+                                 action="store_true",
+                                 help="Generate markdown(.md) RESTCONF API documents"),                    
         ]
         g = optparser.add_option_group("OpenApiPlugin options")
         g.add_options(optlist)
@@ -171,6 +289,8 @@ class OpenApiPlugin(plugin.PyangPlugin):
     def emit(self, ctx, modules, fd):
     
       global currentTag
+      global errorList
+      global warnList
 
       if ctx.opts.outdir is None:
         print("[Error]: Output directory is not mentioned")
@@ -190,8 +310,8 @@ class OpenApiPlugin(plugin.PyangPlugin):
         # delete root '/' as we dont support it.
             
         if len(swaggerDict["paths"]) > 0:
-            if "/" in swaggerDict["paths"]:
-                del(swaggerDict["paths"]["/"])
+            if "/restconf/data/" in swaggerDict["paths"]:
+                del(swaggerDict["paths"]["/restconf/data/"])
 
         if len(swaggerDict["paths"]) <= 0:
             continue
@@ -211,9 +331,23 @@ class OpenApiPlugin(plugin.PyangPlugin):
                 fout = open(yamlFn,'w')
                 fout.write(code)
                 fout.close()
+                mdGen(ctx, module)
         else:        
             with open(ctx.opts.outdir + '/' + module.i_modulename + ".yaml", "w") as spec:
-              spec.write(ordered_dump(swaggerDict, Dumper=yaml.SafeDumper))      
+              spec.write(ordered_dump(swaggerDict, Dumper=yaml.SafeDumper))
+              mdGen(ctx, module)
+    
+      if len(warnList) > 0:
+          print("========= Warnings observed =======")
+          for warn in warnList:
+              print(warn)     
+
+      if len(errorList) > 0:
+          print("========= Errors observed =======")
+          for err in errorList:
+              print(err)
+          print("========= Exiting due to above Errors =======")
+          sys.exit(2)
 
 def walk_module(module):
     for child in module.i_children:
@@ -228,11 +362,19 @@ def add_swagger_tag(module):
     else:
         return
 
-def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
+def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False, xParamsList=[], jsonPayload=OrderedDict()):
 
     firstEncounter = True
     verbPathStr = pathstr
     global currentTag
+    global docJson
+    
+    docObj = None
+    if child.i_config:
+        docObj = docJson["config"]
+    else:
+        docObj = docJson["operstate"] 
+
     if verb == "post":
         pathstrList = pathstr.split('/')
         pathstrList.pop()
@@ -240,8 +382,19 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
         if not verbPathStr.startswith("/"):
             verbPathStr = "/" + verbPathStr
 
+    verbPathStr = "/restconf/data" + verbPathStr
     if verbPathStr not in swaggerDict["paths"]:
         swaggerDict["paths"][verbPathStr] = OrderedDict()
+
+    paramsFilled = False
+    if verbPathStr not in docObj:
+        docObj[verbPathStr] = OrderedDict()
+        docObj[verbPathStr]["parameters"] = []
+    else:
+        paramsFilled = True
+
+    if verb not in docObj[verbPathStr]:
+        docObj[verbPathStr][verb] = OrderedDict()
 
     if verb not in swaggerDict["paths"][verbPathStr]:
         swaggerDict["paths"][verbPathStr][verb] = OrderedDict()
@@ -252,6 +405,21 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
         swaggerDict["paths"][verbPathStr][verb]["parameters"] = []
         swaggerDict["paths"][verbPathStr][verb]["responses"] = copy.deepcopy(merge_two_dicts(responses, verb_responses[verb]))
         firstEncounter = False
+
+    haveXParams = False
+    tempParamsList = []     
+    for entry in xParamsList:
+        if entry["yangName"] not in tempParamsList:
+            tempParamsList.append(entry["yangName"])
+        else:
+            haveXParams = True
+            break
+
+    if haveXParams:
+        swaggerDict["paths"][verbPathStr][verb]["x-params"] = {"varMapping":copy.deepcopy(xParamsList)}
+    
+    if not child.i_config:
+        swaggerDict["paths"][verbPathStr][verb]["x-config"] = "false"
 
     opId = None
     if "operationId" not in swaggerDict["paths"][verbPathStr][verb]:
@@ -267,6 +435,7 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
             desc = ''
         else:
             desc = desc.arg
+        docObj[verbPathStr]["description"] = copy.deepcopy(desc)
         desc = "OperationId: " + opId + "\n" + desc        
         swaggerDict["paths"][verbPathStr][verb]["description"] = desc        
 
@@ -274,6 +443,10 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
         opId = swaggerDict["paths"][verbPathStr][verb]["operationId"]
 
     verbPath = swaggerDict["paths"][verbPathStr][verb]
+    uriPath = swaggerDict["paths"][verbPathStr]
+
+    doc_verbPath = docObj[verbPathStr][verb]
+    doc_uriPath = docObj[verbPathStr]
 
     if not firstEncounter:
         for meta in metadata:
@@ -289,6 +462,8 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
                     metaTag["format"] = meta["format"]
             metaTag["description"] = meta["desc"]
             verbPath["parameters"].append(metaTag)
+            if not paramsFilled:
+                doc_uriPath["parameters"].append(copy.deepcopy(metaTag))
 
 
     if verb in ["post", "put", "patch"]:
@@ -303,7 +478,8 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
             swaggerDict["definitions"][operationDefnName]["allOf"] = []
             bodyTag["schema"]["$ref"] = "#/definitions/" + operationDefnName
             verbPath["parameters"].append(bodyTag)
-            swaggerDict["definitions"][operationDefnName]["allOf"].append({"$ref" : "#/definitions/" + defName})                
+            swaggerDict["definitions"][operationDefnName]["allOf"].append({"$ref" : "#/definitions/" + defName})
+            doc_verbPath["body"] = copy.deepcopy(jsonPayload)
         else:
             bodyTag = None
             for entry in verbPath["parameters"]:
@@ -312,27 +488,128 @@ def swagger_it(child, defName, pathstr, payload, metadata, verb, operId=False):
                     break
             operationDefnName = bodyTag["schema"]["$ref"].split('/')[-1]
             swaggerDict["definitions"][operationDefnName]["allOf"].append({"$ref" : "#/definitions/" + defName})
+            doc_verbPath["body"] = merge_two_dicts(doc_verbPath["body"], copy.deepcopy(jsonPayload))
 
     if verb == "get":
         verbPath["responses"]["200"]["schema"] = OrderedDict()
         verbPath["responses"]["200"]["schema"]["$ref"] = "#/definitions/" + defName
+        doc_verbPath["body"] = copy.deepcopy(jsonPayload)
+
+        # Generate HEAD requests
+        uriPath["head"] = copy.deepcopy(verbPath)
+        uriPath["head"]["operationId"] = 'head_' + verbPath["operationId"][4:] #taking after get_
+        uriPath["head"]["description"] = uriPath["head"]["description"].replace(verbPath["operationId"],uriPath["head"]["operationId"])
+        del(uriPath["head"]["responses"]["200"]["schema"])
+        del(uriPath["head"]["produces"])
+    
+    if verb == "delete":
+        doc_verbPath["body"] = OrderedDict()
+
+def handle_rpc(child, actXpath, pathstr):
+    global currentTag
+    global docJson
+    docObj = docJson["operations"]
+    verbPathStr = "/restconf/operations" + pathstr
+    verb = "post"
+    customName = getOpId(child)
+    DefName = shortenNodeName(child, customName)
+    opId = "rpc_" + DefName
+    add_swagger_tag(child.i_module)
+    
+    jsonPayload_input = OrderedDict()
+    # build input payload
+    input_payload = OrderedDict()       
+    input_child = child.search_one('input', None, child.i_children)
+    if input_child is None:
+        print("There is no input node for RPC ", "Xpath: ", actXpath)    
+    build_payload(input_child, input_payload, pathstr, True, actXpath, True, False, [], jsonPayload_input)    
+    input_Defn = "rpc_input_" + DefName
+    swaggerDict["definitions"][input_Defn] = OrderedDict()
+    swaggerDict["definitions"][input_Defn]["type"] = "object"
+    swaggerDict["definitions"][input_Defn]["properties"] = copy.deepcopy(input_payload)
+
+    # build output payload
+    jsonPayload_output = OrderedDict()
+    output_payload = OrderedDict()       
+    output_child = child.search_one('output', None, child.i_children)
+    if output_child is None:
+        print("There is no output node for RPC ", "Xpath: ", actXpath)
+    build_payload(output_child, output_payload, pathstr, True, actXpath, True, False, [], jsonPayload_output) 
+    output_Defn = "rpc_output_" + DefName
+    swaggerDict["definitions"][output_Defn] = OrderedDict()
+    swaggerDict["definitions"][output_Defn]["type"] = "object"
+    swaggerDict["definitions"][output_Defn]["properties"] = copy.deepcopy(output_payload)        
+
+    if verbPathStr not in swaggerDict["paths"]:
+        swaggerDict["paths"][verbPathStr] = OrderedDict()
+    
+    if verbPathStr not in docObj:
+        docObj[verbPathStr] = OrderedDict()
+    
+    swaggerDict["paths"][verbPathStr][verb] = OrderedDict()
+    swaggerDict["paths"][verbPathStr][verb]["tags"] = [currentTag]
+    
+    # Set Operation ID
+    swaggerDict["paths"][verbPathStr][verb]["operationId"] = opId
+    
+    # Set Description
+    desc = child.search_one('description')
+    if desc is None:
+        desc = ''
+    else:
+        desc = desc.arg
+    docObj[verbPathStr]["description"] = copy.deepcopy(desc)
+    desc = "OperationId: " + opId + "\n" + desc        
+    swaggerDict["paths"][verbPathStr][verb]["description"] = desc
+    verbPath = swaggerDict["paths"][verbPathStr][verb]
+    
+    # Request payload
+    if len(input_payload[child.i_module.i_modulename + ':input']['properties']) > 0:
+        verbPath["parameters"] = []    
+        verbPath["consumes"] = ["application/yang-data+json"]
+        bodyTag = OrderedDict()
+        bodyTag["in"] = "body"
+        bodyTag["name"] = "body"
+        bodyTag["required"] = True
+        bodyTag["schema"] = OrderedDict()
+        bodyTag["schema"]["$ref"] = "#/definitions/" + input_Defn
+        verbPath["parameters"].append(bodyTag)
+
+    # Response payload
+    verbPath["responses"] = copy.deepcopy(merge_two_dicts(responses, verb_responses["rpc"]))        
+    if len(output_payload[child.i_module.i_modulename + ':output']['properties']) > 0:
+        verbPath["produces"] = ["application/yang-data+json"]    
+        verbPath["responses"]["204"]["schema"] = OrderedDict()    
+        verbPath["responses"]["204"]["schema"]["$ref"] = "#/definitions/" + output_Defn    
+
+    docObj[verbPathStr]["parameters"] = []
+    docObj[verbPathStr]["input"] = copy.deepcopy(jsonPayload_input)   
+    docObj[verbPathStr]["output"] = copy.deepcopy(jsonPayload_output)   
 
 def walk_child(child):
     global XpathToBodyTagDict
+    customName =  None
 
     actXpath = statements.mk_path_str(child, True)
     metadata = []
     keyNodesInPath = []
-    pathstr = mk_path_refine(child, metadata, keyNodesInPath)
+    paramsList = []
+    pathstr = mk_path_refine(child, metadata, keyNodesInPath, False, paramsList)
         
     if actXpath in keysToLeafRefObjSet:
         return
 
+    if child.keyword == "rpc":
+        add_swagger_tag(child.i_module)
+        handle_rpc(child, actXpath, pathstr)
+        return 
+
     if child.keyword in ["list", "container", "leaf", "leaf-list"]:
-        payload = OrderedDict()       
+        payload = OrderedDict() 
+        jsonPayload = OrderedDict()   
 
         add_swagger_tag(child.i_module)
-        build_payload(child, payload, pathstr, True, actXpath, True)
+        build_payload(child, payload, pathstr, True, actXpath, True, False, [], jsonPayload)
 
         if len(payload) == 0 and child.i_config == True:
             return
@@ -345,11 +622,13 @@ def walk_child(child):
                         keysToLeafRefObjSet.add(listKeyPath)
                 return
 
-        defName = shortenNodeName(child)
+        customName = getOpId(child)
+        defName = shortenNodeName(child, customName)
 
         if child.i_config == False:   
             payload_get = OrderedDict()
-            build_payload(child, payload_get, pathstr, True, actXpath, True, True)
+            json_payload_get = OrderedDict()
+            build_payload(child, payload_get, pathstr, True, actXpath, True, True, [], json_payload_get)
             if len(payload_get) == 0:
                 return  
 
@@ -357,7 +636,7 @@ def walk_child(child):
             swaggerDict["definitions"][defName_get] = OrderedDict()
             swaggerDict["definitions"][defName_get]["type"] = "object"
             swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)
-            swagger_it(child, defName_get, pathstr, payload_get, metadata, "get", defName_get)
+            swagger_it(child, defName_get, pathstr, payload_get, metadata, "get", defName_get, paramsList, json_payload_get)
         else:
             swaggerDict["definitions"][defName] = OrderedDict()
             swaggerDict["definitions"][defName]["type"] = "object"
@@ -367,22 +646,24 @@ def walk_child(child):
                 if child.keyword == "leaf-list":
                     metadata_leaf_list = []
                     keyNodesInPath_leaf_list = []
-                    pathstr_leaf_list = mk_path_refine(child, metadata_leaf_list, keyNodesInPath_leaf_list, True)                    
+                    paramsLeafList = []
+                    pathstr_leaf_list = mk_path_refine(child, metadata_leaf_list, keyNodesInPath_leaf_list, True, paramsLeafList)                    
 
                 if verb == "get":
                     payload_get = OrderedDict()
-                    build_payload(child, payload_get, pathstr, True, actXpath, True, True)
+                    json_payload_get = OrderedDict()
+                    build_payload(child, payload_get, pathstr, True, actXpath, True, True, [], json_payload_get)
                     if len(payload_get) == 0:
                         continue  
                     defName_get = "get" + '_' + defName
                     swaggerDict["definitions"][defName_get] = OrderedDict()
                     swaggerDict["definitions"][defName_get]["type"] = "object"
                     swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)
-                    swagger_it(child, defName_get, pathstr, payload_get, metadata, verb, defName_get)
+                    swagger_it(child, defName_get, pathstr, payload_get, metadata, verb, defName_get, paramsList, json_payload_get)
 
                     if child.keyword == "leaf-list":
                         defName_get_leaf_list = "get" + '_llist_' + defName
-                        swagger_it(child, defName_get, pathstr_leaf_list, payload_get, metadata_leaf_list, verb, defName_get_leaf_list)
+                        swagger_it(child, defName_get, pathstr_leaf_list, payload_get, metadata_leaf_list, verb, defName_get_leaf_list, paramsLeafList, json_payload_get)
 
                     continue
                 
@@ -395,22 +676,24 @@ def walk_child(child):
                     if isUriKeyInPayload(child,keyNodesInPath):
                         continue
 
-                swagger_it(child, defName, pathstr, payload, metadata, verb)
+                swagger_it(child, defName, pathstr, payload, metadata, verb, False, paramsList, jsonPayload)
                 if verb == "delete" and child.keyword == "leaf-list":
                     defName_del_leaf_list = "del" + '_llist_' + defName
-                    swagger_it(child, defName, pathstr_leaf_list, payload, metadata_leaf_list, verb, defName_del_leaf_list)
+                    swagger_it(child, defName, pathstr_leaf_list, payload, metadata_leaf_list, verb, defName_del_leaf_list, paramsLeafList, jsonPayload)
 
         if  child.keyword == "list":
             listMetaData = copy.deepcopy(metadata)
-            walk_child_for_list_base(child,actXpath,pathstr, listMetaData, defName)
+            listparamsList = copy.deepcopy(paramsList)
+            walk_child_for_list_base(child,actXpath,pathstr, listMetaData, defName, listparamsList)
 
     if hasattr(child, 'i_children'):
         for ch in child.i_children:
             walk_child(ch)
 
-def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=None):
+def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=None, paramsList=[]):
 
     payload = OrderedDict()
+    jsonPayload = OrderedDict()
     pathstrList = pathstr.split('/')
 
     lastNode = pathstrList[-1]
@@ -426,32 +709,36 @@ def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=
 
     for key in child.i_key:
         metadata.pop()
+        if len(paramsList) > 0:
+            paramsList.pop()
 
     add_swagger_tag(child.i_module)    
-    build_payload(child, payload, pathstr, False, "", True)
+    build_payload(child, payload, pathstr, False, "", True, False, [], jsonPayload)
 
     if len(payload) == 0 and child.i_config == True:
         return
 
-    defName = shortenNodeName(child)
+    customName = getOpId(child)
+    defName = shortenNodeName(child, customName)
     defName = "list"+'_'+defName
 
     if child.i_config == False:
         
         payload_get = OrderedDict()
-        build_payload(child, payload_get, pathstr, False, "", True, True)
+        json_payload_get = OrderedDict()
+        build_payload(child, payload_get, pathstr, False, "", True, True, [], json_payload_get)
         
         if len(payload_get) == 0:
             return
 
         defName_get = "get" + '_' + defName
         if nonBaseDefName is not None:
-            swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get, metadata, "get", defName_get)
+            swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get, metadata, "get", defName_get, paramsList, json_payload_get)
         else:
             swaggerDict["definitions"][defName_get] = OrderedDict()
             swaggerDict["definitions"][defName_get]["type"] = "object"
             swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)            
-            swagger_it(child, defName_get, pathstr, payload_get, metadata, "get", defName_get)
+            swagger_it(child, defName_get, pathstr, payload_get, metadata, "get", defName_get, paramsList, json_payload_get)
     else:
         if nonBaseDefName is None:
             swaggerDict["definitions"][defName] = OrderedDict()
@@ -460,28 +747,29 @@ def walk_child_for_list_base(child, actXpath, pathstr, metadata, nonBaseDefName=
 
         for verb in verbs:
             if verb == "get":
-                payload_get = OrderedDict()                
-                build_payload(child, payload_get, pathstr, False, "", True, True)
+                payload_get = OrderedDict()   
+                json_payload_get = OrderedDict()                
+                build_payload(child, payload_get, pathstr, False, "", True, True, [], json_payload_get)
                 
                 if len(payload_get) == 0:
                     continue
 
                 defName_get = "get" + '_' + defName
                 if nonBaseDefName is not None:
-                    swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get, metadata, verb, defName_get)
+                    swagger_it(child, "get" + '_' + nonBaseDefName, pathstr, payload_get, metadata, verb, defName_get, paramsList, json_payload_get)
                 else:
                     swaggerDict["definitions"][defName_get] = OrderedDict()
                     swaggerDict["definitions"][defName_get]["type"] = "object"
                     swaggerDict["definitions"][defName_get]["properties"] = copy.deepcopy(payload_get)
-                    swagger_it(child, defName_get, pathstr, payload_get, metadata, verb, defName_get)
+                    swagger_it(child, defName_get, pathstr, payload_get, metadata, verb, defName_get, paramsList, json_payload_get)
                 continue
             
             if nonBaseDefName is not None:
-                swagger_it(child, nonBaseDefName, pathstr, payload, metadata, verb, verb + '_' + defName)
+                swagger_it(child, nonBaseDefName, pathstr, payload, metadata, verb, verb + '_' + defName, paramsList, jsonPayload)
             else:
-                swagger_it(child, defName, pathstr, payload, metadata, verb, verb + '_' + defName)
+                swagger_it(child, defName, pathstr, payload, metadata, verb, verb + '_' + defName, paramsList, jsonPayload)
 
-def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", firstCall=False, config_false=False, moduleList=[]):
+def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", firstCall=False, config_false=False, moduleList=[], jsonPayloadDict=OrderedDict()):
 
     nodeModuleName = child.i_module.i_modulename
     if nodeModuleName not in moduleList:
@@ -502,6 +790,7 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
         pass
 
     childJson = None
+    payloadJson = None
     if child.keyword == "container" and len(chs) > 0:
         if firstCall:
             nodeName = child.i_module.i_modulename + ':' + child.arg
@@ -511,6 +800,9 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
         payloadDict[nodeName]["type"] = "object"
         payloadDict[nodeName]["properties"] = OrderedDict()
         childJson = payloadDict[nodeName]["properties"]
+
+        jsonPayloadDict[nodeName] = OrderedDict()
+        payloadJson = jsonPayloadDict[nodeName]
     
     elif child.keyword == "list" and len(chs) > 0:
         if firstCall:
@@ -518,7 +810,9 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
         else:
             nodeName = child.arg
         payloadDict[nodeName] = OrderedDict()
+        jsonPayloadDict[nodeName] = [OrderedDict()]      
         returnJson = None
+        payloadreturnJson = None
         
         payloadDict[nodeName]["type"] = "array"
         payloadDict[nodeName]["items"] = OrderedDict()
@@ -530,8 +824,11 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
 
         payloadDict[nodeName]["items"]["properties"] = OrderedDict()
         returnJson = payloadDict[nodeName]["items"]["properties"]
+        payloadreturnJson = jsonPayloadDict[nodeName][0]
 
         childJson = returnJson
+        payloadJson = payloadreturnJson
+
 
     elif child.keyword == "leaf":
 
@@ -540,6 +837,7 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
         else:
             nodeName = child.arg
         payloadDict[nodeName] = OrderedDict()
+        jsonPayloadDict[nodeName] = OrderedDict()
         typeInfo = getType(child)
         enums = None
         if isinstance(typeInfo, tuple):
@@ -557,6 +855,8 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
 
         if 'format' in typeInfo:
             payloadDict[nodeName]["format"] = typeInfo["format"]
+        
+        jsonPayloadDict[nodeName] = dType       
 
     elif child.keyword == "leaf-list":
 
@@ -566,6 +866,7 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
             nodeName = child.arg
 
         payloadDict[nodeName] = OrderedDict()
+        jsonPayloadDict[nodeName] = OrderedDict()
         payloadDict[nodeName]["type"] = "array"
         payloadDict[nodeName]["items"] = OrderedDict()
 
@@ -585,16 +886,62 @@ def build_payload(child, payloadDict, uriPath="", oneInstance=False, Xpath="", f
             payloadDict[nodeName]["items"]["enum"] = enums           
 
         if 'format' in typeInfo:
-            payloadDict[nodeName]["items"]["format"] = typeInfo["format"]            
+            payloadDict[nodeName]["items"]["format"] = typeInfo["format"]   
+
+        jsonPayloadDict[nodeName] = [dType]         
 
     elif child.keyword == "choice" or child.keyword == "case":
         childJson = payloadDict
+        payloadJson = jsonPayloadDict
+    
+    elif child.keyword == "input" or child.keyword == "output":
+        if firstCall:
+            nodeName = child.i_module.i_modulename + ':' + child.keyword
+        else:
+            nodeName = child.keyword
+
+        payloadDict[nodeName] = OrderedDict()
+        payloadDict[nodeName]["type"] = "object"
+        payloadDict[nodeName]["properties"] = OrderedDict()
+        childJson = payloadDict[nodeName]["properties"]   
+
+        jsonPayloadDict[nodeName] =  OrderedDict()  
+        payloadJson = jsonPayloadDict[nodeName]
 
     if hasattr(child, 'i_children'):
         for ch in child.i_children:
-            build_payload(ch,childJson,uriPath, False, Xpath, False, config_false, copy.deepcopy(moduleList))
+            build_payload(ch,childJson,uriPath, False, Xpath, False, config_false, copy.deepcopy(moduleList), payloadJson)
 
-def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False):
+def handleDuplicateParams(node, paramMeta={}):
+    paramNamesList = paramMeta["paramNamesList"]
+    paramsList = paramMeta["paramsList"]
+    paramName = node.arg
+    paramNamesList.append(paramName)
+    paramNameCount = paramNamesList.count(paramName)
+    paramDictEntry = OrderedDict()
+
+    if paramNameCount > 1:
+        origParamName = paramName
+        paramName = paramName + str(paramNameCount-1)
+        while paramName in paramNamesList:
+            paramNameCount = paramNameCount + 1
+            paramName = origParamName + str(paramNameCount-1)
+        paramNamesList.append(paramName)
+    
+    paramDictEntry["uriName"] = paramName
+    paramDictEntry["yangName"] = node.arg 
+    if paramName != node.arg:
+        paramMeta["sameParams"] = True
+    paramsList.append(paramDictEntry)
+    
+    return paramName
+
+def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False, paramsList=[]):
+    paramMeta={}
+    paramMeta["paramNamesList"] = []
+    paramMeta["paramsList"] = []
+    paramMeta["sameParams"] = False
+
     def mk_path(node):
         """Returns the XPath path of the node"""
         if node.keyword in ['choice', 'case']:
@@ -602,8 +949,9 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False):
         def name(node):
             extra = ""
             if node.keyword == "leaf-list" and restconf_leaflist:
-                extraKeys = []      
-                extraKeys.append('{' + node.arg + '}')
+                extraKeys = []     
+                paramName = handleDuplicateParams(node,paramMeta)
+                extraKeys.append('{' + paramName + '}')
                 desc = node.search_one('description')
                 if desc is None:
                     desc = ''
@@ -611,7 +959,7 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False):
                     desc = desc.arg
                 metaInfo = OrderedDict()
                 metaInfo["desc"] = desc
-                metaInfo["name"] = node.arg 
+                metaInfo["name"] = paramName
                 metaInfo["type"] = "string"
                 metaInfo["format"] = ""
                 metadata.append(metaInfo)
@@ -622,8 +970,9 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False):
                 for index, list_key in enumerate(node.i_key):                    
                     keyNodes.append(list_key)
                     if list_key.i_leafref is not None:
-                        keyNodes.append(list_key.i_leafref_ptr[0])
-                    extraKeys.append('{' + list_key.arg + '}')
+                        keyNodes.append(list_key.i_leafref_ptr[0])                    
+                    paramName = handleDuplicateParams(list_key,paramMeta)
+                    extraKeys.append('{' + paramName + '}')
                     desc = list_key.search_one('description')
                     if desc is None:
                         desc = ''
@@ -631,7 +980,7 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False):
                         desc = desc.arg
                     metaInfo = OrderedDict()
                     metaInfo["desc"] = desc
-                    metaInfo["name"] = list_key.arg
+                    metaInfo["name"] = paramName
                     typeInfo = getType(list_key)
                     
                     if isinstance(typeInfo, tuple):
@@ -679,6 +1028,11 @@ def mk_path_refine(node, metadata, keyNodes=[], restconf_leaflist=False):
     xpath = "/".join(final_xpathList)
     if not xpath.startswith('/'):
         xpath = '/' + xpath
+    
+    if paramMeta["sameParams"]:
+        for entry in paramMeta["paramsList"]:
+            paramsList.append(copy.deepcopy(entry))
+
     return xpath
 
 def handle_leafref(node,xpath):
@@ -690,20 +1044,52 @@ def handle_leafref(node,xpath):
         print("leafref not pointing to leaf/leaflist")
         sys.exit(2)
 
-def shortenNodeName(node):
+def getOpId(node):
+    name = None
+    for substmt in node.substmts: 
+        if substmt.keyword.__class__.__name__ == 'tuple':
+            if substmt.keyword[0] == 'sonic-extensions':
+                if substmt.keyword[1] == 'openapi-opid':
+                    name = substmt.arg
+    return name
+
+def shortenNodeName(node, overridenName=None):
     global nodeDict
+    global errorList
+    global warnList
+
     xpath = statements.mk_path_str(node, False)
-    name = node.i_module.i_modulename + xpath.replace('/','_')
+    xpath_prefix = statements.mk_path_str(node, True)
+    if overridenName is None:
+        name = node.i_module.i_modulename + xpath.replace('/','_')
+    else:
+        name = overridenName
+
     name = name.replace('-','_').lower()
     if name not in nodeDict:
         nodeDict[name] = xpath
     else:
-        while name in nodeDict:
-            if xpath == nodeDict[name]:
-                break
-            name = node.i_module.i_modulename + '_' + name
+        if overridenName is None:
+            while name in nodeDict:
+                if xpath == nodeDict[name]:
+                    break
+                name = node.i_module.i_modulename + '_' + name
+                name = name.replace('-','_').lower()
+            nodeDict[name] = xpath
+        else:
+            if xpath != nodeDict[name]:
+                print("[Name collision] at ", xpath, " name: ", name, " is used, override using openapi-opid annotation")
+                sys.exit(2)
+    if len(name) > 150:
+        if overridenName is None:
+            # Generate unique hash
+            mmhash = mmh3.hash(name, signed=False)
+            name = node.i_module.i_modulename + str(mmhash)
             name = name.replace('-','_').lower()
-        nodeDict[name] = xpath
+            nodeDict[name] = xpath
+            warnList.append("[Warn]: Using autogenerated shortened OperId for " + str(xpath_prefix) + " please provide unique manual input through openapi-opid annotation using deviation file if you want to override")
+        if len(name) > 150:
+            errorList.append("[Error: ] OpID is too big for " + str(xpath_prefix) +" please provide unique manual input through openapi-opid annotation using deviation file")
     return name
 
 def getCamelForm(moName):
@@ -830,4 +1216,3 @@ def isUriKeyInPayload(stmt, keyNodesList):
         result = True
     
     return result
-


### PR DESCRIPTION
Features
==============
1) RESTCONF document generator
Description: This feature adds a generation of RESTCONF documents in
md format
2) Added support for HEAD operations
Description: This adds HTTP verb support in OpenAPI generator.
3) Added support for YANG RPC
Fixes
=======
1) Added support for Custom OperationID
Description: OpenAPI requires operationID for each URI. By default
this operID is autogenerated but this commit
provides user to specify custom name
2) Handle params with same name in URI
3) fix issues with respect to prefix name in payload
4) fix issue with operID naming if there is a 'hipen'