### PR TITLE
RESTCONF compliance enhancements

### DIFF
--- a/rest/server/handler.go
+++ b/rest/server/handler.go
@@ -60,6 +60,13 @@ func Process(w http.ResponseWriter, r *http.Request) {
 		goto write_resp
 	}
 
+	// Special handling for HEAD -- ignore the data but set content-length.
+	// HTTP spec says HEAD can return content-length and content-type as if it was a GET.
+	if r.Method == "HEAD" {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+		data = nil
+	}
+
 	rtype, err = resolveResponseContentType(data, r, rc)
 	if err != nil {
 		glog.Errorf("[%s] Failed to resolve response content-type, err=%v", rc.ID, err)
@@ -223,7 +230,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 	var err error
 
 	switch r.Method {
-	case "GET":
+	case "GET", "HEAD":
 		req := translib.GetRequest{
 			Path: args.path,
 		}

--- a/rest/server/handler.go
+++ b/rest/server/handler.go
@@ -20,7 +20,6 @@
 package server
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -275,19 +274,6 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 	}
 
 	return status, content, err
-}
-
-// hostMetadataHandler function handles "GET /.well-known/host-meta"
-// request as per RFC6415. RESTCONF specification requires this for
-// advertising the RESTCONF root path ("/restconf" in our case).
-func hostMetadataHandler(w http.ResponseWriter, r *http.Request) {
-	var data bytes.Buffer
-	data.WriteString("<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>")
-	data.WriteString("<Link rel='restconf' href='/restconf'/>")
-	data.WriteString("</XRD>")
-
-	w.Header().Set("Content-Type", "application/xrd+xml")
-	w.Write(data.Bytes())
 }
 
 // writeErrorResponse writes HTTP error response for a error object

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -442,6 +442,25 @@ func TestProcessGET_error(t *testing.T) {
 	verifyResponse(t, w, 404)
 }
 
+func TestProcessHEAD(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "HEAD", "/api-tests:sample", ""))
+	verifyResponse(t, w, 200)
+
+	if w.Header().Get("Content-Length") == "" {
+		t.Fatalf("Expecting Content-Length response header..")
+	}
+	if w.Body.Len() != 0 {
+		t.Fatalf("Expecting empty body; found %d bytes - %s", w.Body.Len(), w.Body.String())
+	}
+}
+
+func TestProcessHEAD_error(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "HEAD", "/api-tests:sample/error/not-found", ""))
+	verifyResponse(t, w, 404)
+}
+
 func TestProcessPUT(t *testing.T) {
 	w := httptest.NewRecorder()
 	Process(w, prepareRequest(t, "PUT", "/api-tests:sample", "{}"))

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -21,7 +21,6 @@ package server
 
 import (
 	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"net/http"
@@ -80,57 +79,6 @@ func testGet(url string, expStatus int) func(*testing.T) {
 		if w.Code != expStatus {
 			t.Fatalf("Expected response code %d; found %d", expStatus, w.Code)
 		}
-	}
-}
-
-func TestMetadataHandler(t *testing.T) {
-	r := httptest.NewRequest("GET", "/.well-known/host-meta", nil)
-	w := httptest.NewRecorder()
-
-	newDefaultRouter().ServeHTTP(w, r)
-
-	if w.Code != 200 {
-		t.Fatalf("Request failed with status %d", w.Code)
-	}
-
-	ct, _ := parseMediaType(w.Header().Get("content-type"))
-	if ct == nil || ct.Type != "application/xrd+xml" {
-		t.Fatalf("Unexpected content-type '%s'", w.Header().Get("content-type"))
-	}
-
-	data := w.Body.Bytes()
-	if len(data) == 0 {
-		t.Fatalf("No response body")
-	}
-
-	var payload struct {
-		XMLName xml.Name `xml:"XRD"`
-		Links   []struct {
-			Rel  string `xml:"rel,attr"`
-			Href string `xml:"href,attr"`
-		} `xml:"Link"`
-	}
-
-	err := xml.Unmarshal(data, &payload)
-	if err != nil {
-		t.Fatalf("Response parsing failed; err=%v", err)
-	}
-
-	if payload.XMLName.Local != "XRD" ||
-		payload.XMLName.Space != "http://docs.oasis-open.org/ns/xri/xrd-1.0" {
-		t.Fatalf("Invalid response '%s'", data)
-	}
-
-	var rcRoot string
-	for _, x := range payload.Links {
-		if x.Rel == "restconf" {
-			rcRoot = x.Href
-		}
-	}
-
-	t.Logf("Restconf root = '%s'", rcRoot)
-	if rcRoot != "/restconf" {
-		t.Fatalf("Invalid restconf root; expected '/restconf'")
 	}
 }
 

--- a/rest/server/restconf.go
+++ b/rest/server/restconf.go
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+const (
+	mimeYangDataJSON = "application/yang-data+json"
+	mimeYangDataXML  = "application/yang-data+xml"
+
+	restconfPathPrefix     = "/restconf/"
+	restconfDataPathPrefix = "/restconf/data/"
+	restconfOperPathPrefix = "/restconf/operations/"
+)
+
+// restconfCapabilities defines server capabilities
+var restconfCapabilities struct {
+	depth bool // depth query parameter
+}
+
+func init() {
+
+	// Metadata discovery handler
+	AddRoute("hostMetadataHandler", "GET", "/.well-known/host-meta", hostMetadataHandler)
+
+	// RESTCONF capability handler
+	AddRoute("capabilityHandler", "GET",
+		"/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities", capabilityHandler)
+	AddRoute("capabilityHandler", "GET",
+		"/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities/capability", capabilityHandler)
+
+}
+
+// hostMetadataHandler function handles "GET /.well-known/host-meta"
+// request as per RFC6415. RESTCONF specification requires this for
+// advertising the RESTCONF root path ("/restconf" in our case).
+func hostMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	var data bytes.Buffer
+	data.WriteString("<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>")
+	data.WriteString("<Link rel='restconf' href='/restconf'/>")
+	data.WriteString("</XRD>")
+
+	w.Header().Set("Content-Type", "application/xrd+xml")
+	w.Write(data.Bytes())
+}
+
+// capabilityHandler serves RESTCONF capability requests -
+// "GET /restconf/data/ietf-restconf-monitoring:restconf-state/capabilities"
+func capabilityHandler(w http.ResponseWriter, r *http.Request) {
+	var c struct {
+		Capabilities struct {
+			Capability []string `json:"capability"`
+		} `json:"capabilities"`
+	}
+
+	c.Capabilities.Capability = append(c.Capabilities.Capability,
+		"urn:ietf:params:restconf:capability:defaults:1.0?basic-mode=report-all")
+
+	if restconfCapabilities.depth {
+		c.Capabilities.Capability = append(c.Capabilities.Capability,
+			"urn:ietf:params:restconf:capability:depth:1.0")
+	}
+
+	var data []byte
+	if strings.HasSuffix(r.URL.Path, "/capabilities") {
+		data, _ = json.Marshal(&c)
+	} else {
+		data, _ = json.Marshal(&c.Capabilities)
+	}
+
+	// A hack to add module prefix
+	// TODO find better method.. My be ygot?
+	if bytes.HasPrefix(data, []byte("{\"")) {
+		var buff bytes.Buffer
+		buff.WriteString("{\"ietf-restconf-monitoring:")
+		buff.Write(data[2:])
+		data = buff.Bytes()
+	}
+
+	w.Header().Set("Content-Type", mimeYangDataJSON)
+	w.Write(data)
+}

--- a/rest/server/restconf_test.go
+++ b/rest/server/restconf_test.go
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package server
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"log"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMetaHandler(t *testing.T) {
+	r := httptest.NewRequest("GET", "/.well-known/host-meta", nil)
+	w := httptest.NewRecorder()
+
+	newDefaultRouter().ServeHTTP(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("Request failed with status %d", w.Code)
+	}
+
+	ct, _ := parseMediaType(w.Header().Get("content-type"))
+	if ct == nil || ct.Type != "application/xrd+xml" {
+		t.Fatalf("Unexpected content-type '%s'", w.Header().Get("content-type"))
+	}
+
+	data := w.Body.Bytes()
+	if len(data) == 0 {
+		t.Fatalf("No response body")
+	}
+
+	var payload struct {
+		XMLName xml.Name `xml:"XRD"`
+		Links   []struct {
+			Rel  string `xml:"rel,attr"`
+			Href string `xml:"href,attr"`
+		} `xml:"Link"`
+	}
+
+	err := xml.Unmarshal(data, &payload)
+	if err != nil {
+		t.Fatalf("Response parsing failed; err=%v", err)
+	}
+
+	if payload.XMLName.Local != "XRD" ||
+		payload.XMLName.Space != "http://docs.oasis-open.org/ns/xri/xrd-1.0" {
+		t.Fatalf("Invalid response '%s'", data)
+	}
+
+	var rcRoot string
+	for _, x := range payload.Links {
+		if x.Rel == "restconf" {
+			rcRoot = x.Href
+		}
+	}
+
+	t.Logf("Restconf root = '%s'", rcRoot)
+	if rcRoot != "/restconf" {
+		t.Fatalf("Invalid restconf root; expected '/restconf'")
+	}
+}
+
+func TestCapability_1(t *testing.T) {
+	testCapability(t, "/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities")
+}
+
+func TestCapability_2(t *testing.T) {
+	testCapability(t, "/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities/capability")
+}
+
+func testCapability(t *testing.T, path string) {
+	r := httptest.NewRequest("GET", path, nil)
+	w := httptest.NewRecorder()
+	newDefaultRouter().ServeHTTP(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("Request failed with status %d", w.Code)
+	}
+	if len(w.Body.Bytes()) == 0 {
+		t.Fatalf("No response body")
+	}
+	if w.Header().Get("Content-Type") != mimeYangDataJSON {
+		t.Fatalf("Expected content-type=%s, found=%s", mimeYangDataJSON, w.Header().Get("Content-Type"))
+	}
+
+	// Parse capability response
+	var cap interface{}
+	top := make(map[string]interface{})
+	json.Unmarshal(w.Body.Bytes(), &top)
+
+	if c := top["ietf-restconf-monitoring:capabilities"]; c != nil {
+		cap = c.(map[string]interface{})["capability"]
+	} else {
+		cap = top["ietf-restconf-monitoring:capability"]
+	}
+
+	if c, ok := cap.([]interface{}); !ok || len(c) == 0 {
+		log.Fatalf("Could not parse capability info: %s", w.Body.String())
+	}
+}

--- a/rest/server/router.go
+++ b/rest/server/router.go
@@ -367,11 +367,6 @@ func (rs *routeStore) addServiceRoutes() {
 	// Redirect "/ui" to "/ui/index.html"
 	router.Methods("GET").Path("/ui").
 		Handler(http.RedirectHandler("/ui/index.html", http.StatusMovedPermanently))
-
-	// Metadata discovery handler
-	metadataHandler := http.HandlerFunc(hostMetadataHandler)
-	router.Methods("GET").Path("/.well-known/host-meta").
-		Handler(withMiddleware(metadataHandler, "hostMetadataHandler"))
 }
 
 // getRouteMatchInfo returns routeMatchInfo from request context.

--- a/rest/server/router.go
+++ b/rest/server/router.go
@@ -78,6 +78,9 @@ func (router *Router) serveFromTree(path string, r *http.Request, w http.Respons
 	}
 
 	handler := node.handlers[r.Method]
+	if handler == nil && r.Method == "OPTIONS" {
+		handler = router.routes.rcOptsHandler
+	}
 
 	// Node found, but no handler for the method
 	if handler == nil {
@@ -310,11 +313,15 @@ func NewRouter(config RouterConfig) *Router {
 // starting with "/restconf") are maintained in a routeTree. Other routes
 // are maintained in a mux router.
 type routeStore struct {
-	rcRoutes     routeTree // restconf routes
-	rcRouteCount uint32    // number of restconf routes
+	rcRoutes      routeTree    // restconf routes
+	rcOptsHandler http.Handler // OPTIONS handler for restconf routes
+	rcRouteCount  uint32       // number of restconf routes
 
-	muxRoutes     *mux.Router // non-restconf and internal routes (UI, yang)
-	muxRouteCount uint32      // number of routes in mux router
+	muxRoutes      *mux.Router         // non-restconf and internal routes (UI, yang)
+	muxOptsRouter  *mux.Router         // subrouter for OPTIONS handlers
+	muxOptsHandler http.Handler        // OPTIONS handler for mux routes
+	muxOptsData    map[string][]string // path to operations map for mux routes
+	muxRouteCount  uint32              // number of routes in mux router
 
 	svcRoutesAdded bool // indicates if service routes have been registered
 }
@@ -323,12 +330,16 @@ type routeStore struct {
 func newRouteStore() *routeStore {
 	rs := new(routeStore)
 	rs.rcRoutes = make(routeTree)
+	rs.rcOptsHandler = withMiddleware(http.HandlerFunc(rcOptions), "optionsHandler")
 
 	r := mux.NewRouter().StrictSlash(true).UseEncodedPath()
 	r.NotFoundHandler = http.HandlerFunc(notFound)
 	r.MethodNotAllowedHandler = http.HandlerFunc(notAllowed)
 
 	rs.muxRoutes = r
+	rs.muxOptsRouter = r.Methods("OPTIONS").Subrouter()
+	rs.muxOptsData = make(map[string][]string)
+	rs.muxOptsHandler = withMiddleware(http.HandlerFunc(muxOptions), "optionsHandler")
 
 	return rs
 }
@@ -347,6 +358,8 @@ func (rs *routeStore) addRoute(rr *routeRegInfo) {
 func (rs *routeStore) addMuxRoute(rr *routeRegInfo) {
 	h := withMiddleware(rr.handler, rr.name)
 	rs.muxRoutes.Methods(rr.method).Path(rr.path).Handler(h)
+	rs.muxOptsRouter.Path(rr.path).Handler(rs.muxOptsHandler)
+	rs.muxOptsData[rr.path] = append(rs.muxOptsData[rr.path], rr.method)
 	rs.muxRouteCount++
 }
 
@@ -433,4 +446,21 @@ func notAllowed(w http.ResponseWriter, r *http.Request) {
 	glog.V(2).Infof("NOT ALLOWED: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
 	writeErrorResponse(w, r,
 		httpError(http.StatusMethodNotAllowed, "%s Not Allowed", r.Method))
+}
+
+// rcOptions handles OPTIONS for routeTree based paths
+func rcOptions(w http.ResponseWriter, r *http.Request) {
+	match := getRouteMatchInfo(r)
+	var methods []string
+	for k := range match.node.handlers {
+		methods = append(methods, k)
+	}
+	writeOptionsResponse(w, r, match.path, methods)
+}
+
+// muxOptions handles OPTIONS for mux matched paths
+func muxOptions(w http.ResponseWriter, r *http.Request) {
+	match := getRouteMatchInfo(r)
+	routr := getContextValue(r, routerObjContextKey).(*Router)
+	writeOptionsResponse(w, r, match.path, routr.routes.muxOptsData[match.path])
 }


### PR DESCRIPTION
Change summary:

* RESTCONF capability discovery:

Implemented handler for
/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities
path. This will be serviced directly from REST server; will not invoke
any translib API.

* HEAD operation handler:

Added a generic handler for HEAD operation.. REST Server invokes
translib.Get() API but discards response data. Only content-length
header is set in the response.

* OPTIONS handler:

Added generic handler for OPTIONS operation. Supports all http routes
registered through AddRoute() API.
Response includes following headers:
a) allow -- comma separated list of supported operations, resolved
   throgh http route registration data.
b) accept-patch -- only for RESTCONF paths that support PATCH.
