### PR TITLE
Generic REST client for CLI

### DIFF
--- a/CLI/actioner/README_cli_client.md
+++ b/CLI/actioner/README_cli_client.md
@@ -1,0 +1,86 @@
+# Generic REST Client for CLI
+
+Actioner scripts can use the generic rest client **cli_client.py** to communicate to REST Server.
+This client is tailor made to connect to local REST Server and handle the CLI actioner usecases.
+
+To use this tool, first create an `ApiClient` object.
+
+```python
+import cli_client as cc
+
+api = cc.ApiClient()
+```
+
+Create a path object for target REST resource. It accepts parameterized path template and parameter
+values. Path template is similar to the template used by swagger. Parameter values will be URL-encoded
+and substituted in the template to get REST resource path.
+
+```python
+path = cc.Path('/restconf/data/openconfig-acl:acl/acl-sets/acl-set={name},{type}/acl-entries',
+            name='MyNewAccessList', type='ACL_IPV4')
+```
+
+Invoke REST API.. `ApiClient` object supports get, post, put, patch and delete operations.
+All these operations send a REST request and return a response object wrapping the REST response data.
+
+```python
+response = api.get(path)
+```
+
+Check API status through `response.ok()` function, which returns true if API was success - REST server
+returned HTTP 2xx status code. `ok()` function returns false if server returned any other status response.
+Use `response.status_code` to inspect actual status code.
+
+```python
+if response.ok() {
+    respJson = response.content
+    # invoke renderer to display respJson
+} else {
+    print(response.error_message())
+}
+```
+
+If request was successful, `response.content` will hold the response data as JSON dictionary object.
+If request failed, `response.content` will hold error JSON returned by the server. CLI displayable
+error message can be extracted using `response.error_message()` function.
+
+Examples of other REST API calls.
+
+```python
+jsonDict = {}
+jsonDict["acl-set"]=[{ "name":the_acl_name, .... }] # construct your request data json
+
+# POST request
+response = api.post(path, data=jsonDict)
+
+# PUT request
+reponse = api.put(path, data=jsonDict)
+
+# PATCH request
+response = api.patch(path, data=jsonDict)
+
+# DELETE request
+response = api.delete(path)
+```
+
+Above example used `response.error_message()` function to get displayable error message from
+the REST response. REST server always returns error information in standard RESTCONF error format.
+The `error_message()` function looks for the **error-message** attribute to get user displayable message.
+A generic message will be returned based on **error-tag** attribute value if there was no **error-message**
+attribute. This can be customized through an error formatter function as shown below.
+Default error formatter is sufficient for most of the cases.
+
+```python
+if not response.ok():
+     print(response.error_message(formatter_func=my_new_error_message_formatter))
+```
+
+The custom formtter function would receive RESTCONF error json and should return a string.
+Below is a sample implementation which uses error-type attribute to format an error message.
+
+```python
+def my_new_error_message_formatter(status_code, error_entry):
+    if err_entry['error-type'] == 'protocol':
+        return "System error.. Please reboot!!"
+    return "Application error.. Please retry."
+```

--- a/CLI/actioner/cli_client.py
+++ b/CLI/actioner/cli_client.py
@@ -1,0 +1,192 @@
+################################################################################
+#                                                                              #
+#  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
+#  its subsidiaries.                                                           #
+#                                                                              #
+#  Licensed under the Apache License, Version 2.0 (the "License");             #
+#  you may not use this file except in compliance with the License.            #
+#  You may obtain a copy of the License at                                     #
+#                                                                              #
+#     http://www.apache.org/licenses/LICENSE-2.0                               #
+#                                                                              #
+#  Unless required by applicable law or agreed to in writing, software         #
+#  distributed under the License is distributed on an "AS IS" BASIS,           #
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#  See the License for the specific language governing permissions and         #
+#  limitations under the License.                                              #
+#                                                                              #
+################################################################################
+
+import os
+import json
+import urllib3
+import requests
+from requests.structures import CaseInsensitiveDict
+from six.moves.urllib.parse import quote
+from collections import OrderedDict
+from cli_log import log_warning
+
+urllib3.disable_warnings()
+
+class ApiClient(object):
+    """REST API client to connect to the SONiC management REST server.
+    Customized for CLI actioner use.
+    """
+
+    # Initialize API root and session 
+    __api_root = os.getenv('REST_API_ROOT', 'https://localhost')
+    __session = requests.Session()
+
+
+    def request(self, method, path, data=None, headers={}, query=None):
+
+        url = '{0}{1}'.format(ApiClient.__api_root, path)
+
+        req_headers = CaseInsensitiveDict({ 'User-Agent': 'sonic-cli' })
+        req_headers.update(headers)
+
+        body = None
+        if data is not None:
+            if 'Content-Type' not in req_headers:
+                req_headers['Content-Type'] = 'application/yang-data+json'
+            body = json.dumps(data)
+
+        try:
+            r = ApiClient.__session.request(
+                method,
+                url,
+                headers=req_headers,
+                data=body,
+                params=query,
+                verify=False)
+
+            return Response(r)
+
+        except requests.RequestException as e:
+            log_warning('cli_client request exception: ' + str(e))
+            #TODO have more specific error message based
+            msg = '%Error: Could not connect to Management REST Server'
+            return ApiClient.__new_error_response(msg)
+
+    def post(self, path, data):
+        return self.request("POST", path, data)
+
+    def get(self, path, depth=None):
+        q = self.prepare_query(depth=depth)
+        return self.request("GET", path, query=q)
+
+    def head(self, path, depth=None):
+        q = self.prepare_query(depth=depth)
+        return self.request("HEAD", path, query=q)
+
+    def put(self, path, data):
+        return self.request("PUT", path, data)
+
+    def patch(self, path, data):
+        return self.request("PATCH", path, data)
+
+    def delete(self, path, ignore404=True):
+        resp = self.request("DELETE", path, data=None)
+        if ignore404 and resp.status_code == 404:
+            resp.status_code = 204
+            resp.content = None
+        return resp
+
+    @staticmethod
+    def prepare_query(depth=None):
+        query = {}
+        if depth != None and depth != "unbounded":
+            query["depth"] = depth
+        return query
+
+    @staticmethod
+    def __new_error_response(errMessage, errType='client', errTag='operation-failed'):
+        r = Response(requests.Response())
+        r.content = {'ietf-restconf:errors':{ 'error':[ {
+            'error-type':errType, 'error-tag':errTag, 'error-message':errMessage }]}}
+        return r
+
+    def cli_not_implemented(self, hint):
+        return self.__new_error_response('%Error: not implemented {0}'.format(hint))
+
+
+class Path(object):
+    def __init__(self, template, **kwargs):
+        self.template = template
+        self.params = kwargs
+        self.path = template
+        for k, v in kwargs.items():
+            self.path = self.path.replace('{%s}' % k, quote(v, safe=''))
+
+    def __str__(self):
+        return self.path
+
+
+class Response(object):
+    def __init__(self, response):
+        self.response = response
+        self.status_code = response.status_code
+        self.content = response.content
+
+        try:
+            if response.content is None or len(response.content) == 0:
+                self.content = None
+            elif has_json_content(response):
+                self.content = json.loads(response.content, object_pairs_hook=OrderedDict)
+        except ValueError:
+            log_warning('Server returned invalid json! using raw content..')
+            self.content = response.content
+
+    def ok(self):
+        return self.status_code >= 200 and self.status_code <= 299
+
+    def errors(self):
+        if self.ok():
+            return {}
+
+        errors = self.content
+
+        if(not isinstance(errors, dict)):
+            errors = {"error": errors}  # convert to dict for consistency
+        elif('ietf-restconf:errors' in errors):
+            errors = errors['ietf-restconf:errors']
+
+        return errors
+
+    def error_message(self, formatter_func=None):
+        err = self.errors().get('error')
+        if err == None:
+            return None
+        if isinstance(err, list):
+            err = err[0]
+        if isinstance(err, dict):
+            if formatter_func is not None:
+                return formatter_func(self.status_code, err)
+            return default_error_message_formatter(self.status_code, err)
+        return str(err)
+
+    def __getitem__(self, key):
+        return self.content[key]
+
+def has_json_content(resp):
+    ctype = resp.headers.get('Content-Type')
+    return (ctype is not None and 'json' in ctype)
+
+def default_error_message_formatter(status_code, err_entry):
+    if 'error-message' in err_entry:
+        err_msg = err_entry['error-message']
+        return add_error_prefix(err_msg)
+    err_tag = err_entry.get('error-tag')
+    if err_tag == 'invalid-value':
+        return '%Error: validation failed'
+    if err_tag == 'operation-not-supported':
+        return '%Error: not supported'
+    if err_tag == 'access-denied':
+        return '%Error: not authorized'
+    return '%Error: operation failed'
+
+def add_error_prefix(err_msg):
+    if not err_msg.startswith("%Error"):
+        return '%Error: ' + err_msg
+    return err_msg
+

--- a/CLI/actioner/cli_client.py
+++ b/CLI/actioner/cli_client.py
@@ -155,7 +155,7 @@ class Response(object):
 
     def error_message(self, formatter_func=None):
         err = self.errors().get('error')
-        if err == None:
+        if err is None:
             return None
         if isinstance(err, list):
             err = err[0]

--- a/CLI/actioner/cli_log.py
+++ b/CLI/actioner/cli_log.py
@@ -1,0 +1,59 @@
+################################################################################
+#                                                                              #
+#  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
+#  its subsidiaries.                                                           #
+#                                                                              #
+#  Licensed under the Apache License, Version 2.0 (the "License");             #
+#  you may not use this file except in compliance with the License.            #
+#  You may obtain a copy of the License at                                     #
+#                                                                              #
+#     http://www.apache.org/licenses/LICENSE-2.0                               #
+#                                                                              #
+#  Unless required by applicable law or agreed to in writing, software         #
+#  distributed under the License is distributed on an "AS IS" BASIS,           #
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#  See the License for the specific language governing permissions and         #
+#  limitations under the License.                                              #
+#                                                                              #
+################################################################################
+
+import os
+import syslog
+import inspect
+
+syslog.openlog('sonic-cli')
+__enable_debug = (os.getenv("DEBUG") is not None)
+__enable_print = (os.getenv("LOGTOSCREEN") is not None)
+__severity_str = [ 'EMERG', 'ALERT', 'CRIT', 'ERROR', 'WARN', 'NOTICE', 'INFO', 'DEBUG' ]
+
+
+def log_debug(msg):
+    if __enable_debug:
+        __write_log(syslog.LOG_DEBUG, msg)
+
+def log_info(msg):
+    __write_log(syslog.LOG_INFO, msg)
+
+def log_warning(msg):
+    __write_log(syslog.LOG_WARNING, msg)
+
+def log_error(msg):
+    __write_log(syslog.LOG_ERR, msg)
+
+
+def __write_log(severity, msg):
+    if not isinstance(msg, basestring):
+        msg = str(msg)
+
+    syslog.syslog(severity, msg)
+
+    if __enable_print:
+        caller_frame = inspect.stack()[2][0]
+        frame_info = inspect.getframeinfo(caller_frame)
+        for line in msg.split('\n'):
+            print('[{}:{}/{}] {}:: {}'.format(
+                os.path.basename(frame_info.filename),
+                frame_info.lineno,
+                frame_info.function,
+                __severity_str[severity],
+                line))

--- a/CLI/actioner/sonic-cli-pfm.py
+++ b/CLI/actioner/sonic-cli-pfm.py
@@ -18,20 +18,12 @@
 ###########################################################################
 
 import sys
-import time
-import json
-import ast
-import openconfig_platform_client
+import cli_client as cc
 from rpipe_utils import pipestr
-from openconfig_platform_client.rest import ApiException
 from scripts.render_cli import show_cli_output
 
 
-import urllib3
-urllib3.disable_warnings()
-
 blocked_fields = {'parent':0, 'used_power':0, 'allocated_power':0, 'temperature':0}
-plugins = dict()
 
 def filter_json_value(value):
     for key,val in value.items():
@@ -46,48 +38,19 @@ def filter_json_value(value):
 
     return value
 
-def register(func):
-    """Register sdk client method as a plug-in"""
-    plugins[func.__name__] = func
-    return func
-
-
-def call_method(name, args):
-    method = plugins[name]
-    return method(args)
-
-def generate_body(func, args):
-    body = None
-    # Get the rules of all ACL table entries.
-
-    if func.__name__ == 'get_openconfig_platform_components':
-        keypath = []
-
-    else:
-       body = {}
-
-    return keypath,body
-
+def get_openconfig_platform_components(*args):
+    path = cc.Path('/restconf/data/openconfig-platform:components')
+    return cc.ApiClient().get(path)
 
 def run(func, args):
-    c = openconfig_platform_client.Configuration()
-    c.verify_ssl = False
-    aa = openconfig_platform_client.OpenconfigPlatformApi(api_client=openconfig_platform_client.ApiClient(configuration=c))
+    # lookup and invoke the function name passed by CLI
+    response = globals()[func](*args)
 
-    # create a body block
-    keypath, body = generate_body(func, args)
-
-    try:
-        if body is not None:
-           api_response = getattr(aa,func.__name__)(*keypath, body=body)
-
-        else :
-           api_response = getattr(aa,func.__name__)(*keypath)
-     
+    if response.ok():
+        api_response = response.content
         if api_response is None:
-            print ("Success")
+            return
         else:
-            api_response = aa.api_client.sanitize_for_serialization(api_response)
             value =  api_response['openconfig-platform:components']['component'][0]['state']
 	    if value is None:
                 return
@@ -97,32 +60,14 @@ def run(func, args):
 	            value['oper-status'] = temp[len(temp) - 1]
             show_cli_output(sys.argv[2],filter_json_value(value))
 
-    except ApiException as e:
-        if e.body != "":
-            body = json.loads(e.body)
-            if "ietf-restconf:errors" in body:
-                 err = body["ietf-restconf:errors"]
-                 if "error" in err:
-                     errList = err["error"]
-
-                     errDict = {}
-                     for dict in errList:
-                         for k, v in dict.iteritems():
-                              errDict[k] = v
-
-                     if "error-message" in errDict:
-                         print "%Error: " + errDict["error-message"]
-                         return
-                     print "%Error: Application Failure"
-                     return
-            print "%Error: Application Failure"
-        else:
-            print "Failed"
+    else:
+        print(response.error_message())
+        return 1
 
 if __name__ == '__main__':
 
     pipestr().write(sys.argv)
     #pdb.set_trace()
-    func = eval(sys.argv[1], globals(), openconfig_platform_client.OpenconfigPlatformApi.__dict__)
+    func = sys.argv[1]
     run(func, sys.argv[2:])
 

--- a/models/codegen.config
+++ b/models/codegen.config
@@ -1,0 +1,55 @@
+################################################################################
+#                                                                              #
+#  Copyright 2020 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
+#  its subsidiaries.                                                           #
+#                                                                              #
+#  Licensed under the Apache License, Version 2.0 (the "License");             #
+#  you may not use this file except in compliance with the License.            #
+#  You may obtain a copy of the License at                                     #
+#                                                                              #
+#     http://www.apache.org/licenses/LICENSE-2.0                               #
+#                                                                              #
+#  Unless required by applicable law or agreed to in writing, software         #
+#  distributed under the License is distributed on an "AS IS" BASIS,           #
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#  See the License for the specific language governing permissions and         #
+#  limitations under the License.                                              #
+#                                                                              #
+################################################################################
+
+# Build time configurations for swagger codegen
+# Use makefile syntax
+
+##
+# YANGAPI_EXCLUDES indicates the yang modules to be excluded from codegen.
+# Server and client code will not be generated for these yangs modules.
+# By default server code will be generated for all yangs under models/yang
+# and models/yang/sonic directories. Note that each entry should be yang
+# module name which is used for generated yaml file name.
+YANGAPI_EXCLUDES += 
+
+##
+# PY_YANGAPI_CLIENTS indicates the yang modules for which python client
+# sdk code should be generated. By default client sdk code will not be
+# generated to save build time and space. YANGAPI_EXCLUDES has priority
+# over this list. Note that the entry should be the yang module name
+# which is used for generated yaml file name.
+PY_YANGAPI_CLIENTS += 
+PY_YANGAPI_CLIENTS += openconfig-acl
+PY_YANGAPI_CLIENTS += openconfig-interfaces
+PY_YANGAPI_CLIENTS += openconfig-lldp
+PY_YANGAPI_CLIENTS += openconfig-system
+
+##
+# OPENAPI_EXCLUDES indicates the OpenAPI specs to be excluded from codegen.
+# By default all yaml files under models/openapi directory are considered
+# for codegen. Items should be the yaml file name without the .yaml extension.
+# Eg: vlan.yaml should be specified as "OPENAPI_EXCLUDES += vlan"
+OPENAPI_EXCLUDES +=
+
+##
+# PY_OPENAPI_CLIENTS indicates the OpenAPI specs for which python client
+# sdk code should be generated. By default client sdk code is not generated.
+# Items should be the yaml file name without the .yaml extension. Note
+# that OPENAPI_EXCLUDES has priority over this list.
+PY_OPENAPI_CLIENTS +=

--- a/models/openapi_codegen.mk
+++ b/models/openapi_codegen.mk
@@ -33,19 +33,24 @@ SERVER_DIST_GO		:= $(SERVER_DIST_DIR)/swagger
 SERVER_DIST_UI		:= $(SERVER_DIST_DIR)/ui
 SERVER_DIST_UI_HOME	:= $(SERVER_DIST_DIR)/ui/index.html
 
+# Load codegen preferences
+include codegen.config
+
 YANGAPI_DIR     := $(TOPDIR)/build/yaml
 YANGAPI_SPECS   := $(wildcard $(YANGAPI_DIR)/*.yaml)
-YANGAPI_NAMES   := $(basename $(notdir $(YANGAPI_SPECS)))
+YANGAPI_NAMES   := $(filter-out $(YANGAPI_EXCLUDES), $(basename $(notdir $(YANGAPI_SPECS))))
 YANGAPI_SERVERS := $(addsuffix /.yangapi_done, $(addprefix $(SERVER_CODEGEN_DIR)/, $(YANGAPI_NAMES)))
 
 OPENAPI_DIR   := openapi
 OPENAPI_SPECS := $(shell find $(OPENAPI_DIR) -name '*.yaml' | sort)
-OPENAPI_NAMES := $(basename $(notdir $(OPENAPI_SPECS)))
+OPENAPI_NAMES := $(filter-out $(OPENAPI_EXCLUDES), $(basename $(notdir $(OPENAPI_SPECS))))
 OPENAPI_SERVERS := $(addsuffix /.openapi_done, $(addprefix $(SERVER_CODEGEN_DIR)/, $(OPENAPI_NAMES)))
 
+PY_YANGAPI_NAMES       := $(filter $(YANGAPI_NAMES), $(PY_YANGAPI_CLIENTS))
+PY_OPENAPI_NAMES       := $(filter $(OPENAPI_NAMES), $(PY_OPENAPI_CLIENTS))
 PY_CLIENT_CODEGEN_DIR  := $(BUILD_DIR)/swagger_client_py
-PY_CLIENT_TARGETS := $(addsuffix .yangapi_client_done, $(addprefix $(PY_CLIENT_CODEGEN_DIR)/, $(YANGAPI_NAMES))) \
-                     $(addsuffix .openapi_client_done, $(addprefix $(PY_CLIENT_CODEGEN_DIR)/, $(OPENAPI_NAMES)))
+PY_CLIENT_TARGETS := $(addsuffix .yangapi_client_done, $(addprefix $(PY_CLIENT_CODEGEN_DIR)/, $(PY_YANGAPI_NAMES)))
+PY_CLIENT_TARGETS += $(addsuffix .openapi_client_done, $(addprefix $(PY_CLIENT_CODEGEN_DIR)/, $(PY_OPENAPI_NAMES)))
 
 UIGEN_DIR  = $(TOPDIR)/tools/ui_gen
 UIGEN_SRCS = $(shell find $(UIGEN_DIR) -type f)
@@ -63,6 +68,7 @@ $(SERVER_DIST_UI_HOME): $(YANGAPI_SERVERS) $(OPENAPI_SERVERS) $(UIGEN_SRCS)
 	$(UIGEN_DIR)/src/uigen.py
 
 py-client: $(PY_CLIENT_TARGETS) | $(PY_CLIENT_CODEGEN_DIR)/.
+	@echo $(basename $(^F)) > $(PY_CLIENT_CODEGEN_DIR)/py_client
 
 
 .SECONDEXPANSION:


### PR DESCRIPTION
Change summary:

* Python REST client for CLI

cli_client.py defines a geneic python REST client for CLI actioners.
Swagger generated client sdk is bulky and CLI uses very very small
subset of the APIs it provides. This generic client is lightweight and
is customized for CLI to management REST server communication.

Sample usage (details are in README_cli_client.md):

```python
  api = cli_client.ApiClient()
  path = cli_client.Path('/restconf/data/sonic-port:sonic-port')
  response = api.get(path)
  if response.ok():
      process_data(response.content)
  else:
      print(response.error_message())
```

cli_log.py defines APIs to write log messages from CLI actioners.
Logs are written to syslog. They are also written to screen if env
variable LOGTOSCREEN is set.

* Generate swagger python client sdk for select models

Disabled automatic generation of swagger client sdk for all yang and
openapi models. CLI actioners are encouraged to use generic REST client.
Client sdk generation can be enabled for select models through an entry
in models/codegen.config file.

*  Migrate platform CLIs to generic REST client

Modified `show platform` CLI actioner to use new Generic REST client
to demonstrate the usage of new client. Disabled generation of swagger
client sdk code for openconfig-platform.yang.