### PR TITLE
Fix payload of 'ip access-list XYZ' CLI

### DIFF
--- a/CLI/actioner/sonic-cli-acl.py
+++ b/CLI/actioner/sonic-cli-acl.py
@@ -58,13 +58,17 @@ def generate_body(func, args):
        keypath = [ args[0], args[1] ]
 
     # Configure ACL table
-    elif func.__name__ == 'patch_openconfig_acl_acl_acl_sets_acl_set' :
-       keypath = [ args[0], args[1] ]
-       body = { "openconfig-acl:config": {
+    elif func.__name__ == 'patch_list_openconfig_acl_acl_acl_sets_acl_set' :
+       keypath = []
+       body = { "openconfig-acl:acl-set": [{
                    "name": args[0],
                    "type": args[1],
-                   "description": ""
-                 }
+                   "config": {
+                      "name": args[0],
+                      "type": args[1],
+                      "description": ""
+                   }
+                 }]
               }
 
     # Configure ACL rule specific to an ACL table

--- a/CLI/clitree/cli-xml/acl.xml
+++ b/CLI/clitree/cli-xml/acl.xml
@@ -111,7 +111,7 @@ limitations under the License.
              ptype="STRING_63"
              >
         </PARAM>
-        <ACTION>python $SONIC_CLI_ROOT/sonic-cli-acl.py patch_openconfig_acl_acl_acl_sets_acl_set ${access-list-name} ACL_IPV4</ACTION>
+        <ACTION>python $SONIC_CLI_ROOT/sonic-cli-acl.py patch_list_openconfig_acl_acl_acl_sets_acl_set ${access-list-name} ACL_IPV4</ACTION>
     </COMMAND>
 
 <!-- no ip access-list -->


### PR DESCRIPTION
CLI handler for 'ip access-list XYZ' was not sednding RESTCONF compliant
payload earlier. New ygot code does not accept it. Modified the actioner
to use 'PATCH /restconf/data/openconfig-acl:acl/acl-sets/acl-set'
request with correct payload.