### PR TITLE
Yang library advertisement and yang file download

### DIFF
--- a/rest/server/restconf.go
+++ b/rest/server/restconf.go
@@ -45,6 +45,9 @@ func init() {
 	// Metadata discovery handler
 	AddRoute("hostMetadataHandler", "GET", "/.well-known/host-meta", hostMetadataHandler)
 
+	// yanglib version handler
+	AddRoute("yanglibVersionHandler", "GET", "/restconf/yang-library-version", yanglibVersionHandler)
+
 	// RESTCONF capability handler
 	AddRoute("capabilityHandler", "GET",
 		"/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities", capabilityHandler)
@@ -63,6 +66,27 @@ func hostMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	data.WriteString("</XRD>")
 
 	w.Header().Set("Content-Type", "application/xrd+xml")
+	w.Write(data.Bytes())
+}
+
+// yanglibVersionHandler handles "GET /restconf/yang-library-version"
+// request as per RFC8040. Yanglib version supported is "2016-06-21"
+func yanglibVersionHandler(w http.ResponseWriter, r *http.Request) {
+	var data bytes.Buffer
+	var contentType string
+	accept := r.Header.Get("Accept")
+
+	// Rudimentary content negotiation
+	if strings.Contains(accept, mimeYangDataXML) {
+		contentType = mimeYangDataXML
+		data.WriteString("<yang-library-version xmlns='urn:ietf:params:xml:ns:yang:ietf-restconf'>")
+		data.WriteString("2016-06-21</yang-library-version>")
+	} else {
+		contentType = mimeYangDataJSON
+		data.WriteString("{\"ietf-restconf:yang-library-version\": \"2016-06-21\"}")
+	}
+
+	w.Header().Set("Content-Type", contentType)
 	w.Write(data.Bytes())
 }
 


### PR DESCRIPTION
1\) Enhanced REST server to handle "GET /restconf/yang-library-version"
request to advertise yang library version (RFC8040, section 3.3.3).
Always returns "2016-06-21".

2\) REST server now supports "GET /models/yang/xxxxx.yang" requests to
download yang files from the device. These links are also advertised
through schema URLs in the ietf-yang-library responses. Schema URL uses
an ipv4 address of eth0. Requires restart of REST server to reflect
changes to eth0 ip address.