### PR TITLE
RESTCONF RPC operations

### DIFF
--- a/rest/server/handler.go
+++ b/rest/server/handler.go
@@ -235,8 +235,8 @@ func trimRestconfPrefix(path string) string {
 func isOperationsRequest(r *http.Request) bool {
 	k := strings.Index(r.URL.Path, restconfOperPathPrefix)
 	return k >= 0
-	//FIXME URI pattern will not help identifying yang action APIs.
-	//Use swagger generated API name instead???
+	//TODO handle yang actions.. URL pattern cannot identify action requests.
+	// Works for now as current yang-to-openapi generator does not support them.
 }
 
 // translibArgs holds arguments for invoking translib APIs.
@@ -259,7 +259,7 @@ func (args *translibArgs) parseMethod(r *http.Request, rc *RequestContext) error
 			args.method = r.Method
 		}
 	default:
-		glog.Errorf("[%s] Unknown method '%v'", rc.ID, r.Method)
+		glog.Warningf("[%s] Unknown method '%v'", rc.ID, r.Method)
 		return httpBadRequest("Invalid method")
 	}
 	return nil

--- a/rest/server/handler_test.go
+++ b/rest/server/handler_test.go
@@ -223,6 +223,16 @@ func TestPathConv(t *testing.T) {
 		"/myroot/restconf/data/id=TEST1",
 		"/id[name=TEST1]"))
 
+	t.Run("rcoper", testPathConv(
+		"/restconf/operations/hello-world",
+		"/restconf/operations/hello-world",
+		"/hello-world"))
+
+	t.Run("x_rcoper", testPathConv(
+		"/myroot/restconf/operations/hello-world",
+		"/myroot/restconf/operations/hello-world",
+		"/hello-world"))
+
 	t.Run("no_template", testPathConv(
 		"*",
 		"/test/id=NOTEMPLATE",
@@ -602,6 +612,20 @@ func TestProcessPOST_error(t *testing.T) {
 	w := httptest.NewRecorder()
 	Process(w, prepareRequest(t, "POST", "/api-tests:sample/error/invalid-args", "{}"))
 	verifyResponse(t, w, 400)
+}
+
+func TestProcessRPC(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "POST", "/restconf/operations/api-tests:my-echo",
+		"{\"/api-tests:input\":{\"message\":\"Hii\"}}"))
+	verifyResponse(t, w, 200)
+}
+
+func TestProcessRPC_error(t *testing.T) {
+	w := httptest.NewRecorder()
+	Process(w, prepareRequest(t, "POST", "/restconf/operations/api-tests:my-echo",
+		"{\"api-tests:input\":{\"error-type\":\"not-supported\"}}"))
+	verifyResponse(t, w, 405)
 }
 
 func TestProcessPATCH(t *testing.T) {

--- a/rest/server/restconf.go
+++ b/rest/server/restconf.go
@@ -24,6 +24,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 const (
@@ -118,6 +120,7 @@ func operationsDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
 		operations[name] = emptyValue
 	}
 
+	glog.Infof("Found %d operation nodes", len(operations))
 	dataJSON := map[string]interface{}{
 		"operations": operations,
 	}
@@ -127,6 +130,7 @@ func operationsDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", mimeYangDataJSON)
 		w.Write(data)
 	} else {
+		glog.Warning("Marshal error:", err)
 		writeErrorResponse(w, r, err)
 	}
 }

--- a/rest/server/restconf_test.go
+++ b/rest/server/restconf_test.go
@@ -23,7 +23,10 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"log"
+	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -91,6 +94,69 @@ func testCapability(t *testing.T, path string) {
 	w := httptest.NewRecorder()
 	newDefaultRouter().ServeHTTP(w, r)
 
+	// Parse capability response
+	var cap interface{}
+	top := make(map[string]interface{})
+	parseResponseJSON(t, w, &top)
+
+	if c := top["ietf-restconf-monitoring:capabilities"]; c != nil {
+		cap = c.(map[string]interface{})["capability"]
+	} else {
+		cap = top["ietf-restconf-monitoring:capability"]
+	}
+
+	if c, ok := cap.([]interface{}); !ok || len(c) == 0 {
+		log.Fatalf("Could not parse capability info: %s", w.Body.String())
+	}
+}
+
+func TestOpsDiscovery_none(t *testing.T) {
+	testOpsDiscovery(t, nil)
+}
+
+func TestOpsDiscovery_one(t *testing.T) {
+	testOpsDiscovery(t, []string{"testing:system-restart"})
+}
+
+func TestOpsDiscovery(t *testing.T) {
+	testOpsDiscovery(t, []string{"testing:cpu", "testing:clock", "hello:world", "foo:bar"})
+}
+
+func testOpsDiscovery(t *testing.T, ops []string) {
+	s := newEmptyRouter()
+	f := func(w http.ResponseWriter, r *http.Request) {}
+	s.addRoute("opsDiscovery", "GET",
+		"/restconf/operations", operationsDiscoveryHandler)
+	for _, op := range ops {
+		s.addRoute(op, "POST", "/restconf/operations/"+op, f)
+	}
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest("GET", "/restconf/operations", nil))
+
+	var resp struct {
+		Ops map[string][]interface{} `json:"operations"`
+	}
+
+	parseResponseJSON(t, w, &resp)
+	if resp.Ops == nil {
+		t.Fatal("Response does not contain 'operations' object:", resp)
+	}
+
+	var respOps []string
+	for op := range resp.Ops {
+		respOps = append(respOps, op)
+	}
+
+	sort.Strings(ops)
+	sort.Strings(respOps)
+	if !reflect.DeepEqual(respOps, ops) {
+		t.Fatalf("Response does not include expected operations list\n"+
+			"expected: %v\nfound: %v", ops, respOps)
+	}
+}
+
+func parseResponseJSON(t *testing.T, w *httptest.ResponseRecorder, resp interface{}) {
 	if w.Code != 200 {
 		t.Fatalf("Request failed with status %d", w.Code)
 	}
@@ -101,18 +167,8 @@ func testCapability(t *testing.T, path string) {
 		t.Fatalf("Expected content-type=%s, found=%s", mimeYangDataJSON, w.Header().Get("Content-Type"))
 	}
 
-	// Parse capability response
-	var cap interface{}
-	top := make(map[string]interface{})
-	json.Unmarshal(w.Body.Bytes(), &top)
-
-	if c := top["ietf-restconf-monitoring:capabilities"]; c != nil {
-		cap = c.(map[string]interface{})["capability"]
-	} else {
-		cap = top["ietf-restconf-monitoring:capability"]
-	}
-
-	if c, ok := cap.([]interface{}); !ok || len(c) == 0 {
-		log.Fatalf("Could not parse capability info: %s", w.Body.String())
+	err := json.Unmarshal(w.Body.Bytes(), resp)
+	if err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 }


### PR DESCRIPTION
Handle yang rpc operations through RESTCONF operations resource
requests -- "POST /restconf/operations/xxxxx". Here "xxxxx" is the yang
module qualified rpc name (like "ietf-system:system-restart"). Payload
should contain the json encoded rpc input data; or empty if rpc does not
define any input. REST server invokes `translib.Action` API to handle
these requests. On success, REST server returns 200 status with json
encoded rpc output data.

Handle "GET /restconf/operations" requests to return available yang rpc
operations. Clients can use this to discover avaiable rpc operations
resources. Sample output (assuming device supports 2 rpcs):
```
{
  "operations": {
    { "ietf-system:system-restart" : [null] },
    { "foo:bar" : [null] }
  }
}
```

Reference: RFC8040, section 3.3.2