### PR TITLE
Query parameters infra

### DIFF
--- a/CLI/actioner/cli_client.py
+++ b/CLI/actioner/cli_client.py
@@ -73,7 +73,7 @@ class ApiClient(object):
 
     def get(self, path, depth=None, ignore404=True, response_type=None):
         q = self.prepare_query(depth=depth)
-        resp = self.request("GET", path, response_type=response_type)
+        resp = self.request("GET", path, query=q, response_type=response_type)
         if ignore404 and resp.status_code == 404:
             resp.status_code = 200
             resp.content = None

--- a/rest/server/query.go
+++ b/rest/server/query.go
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2020 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// parseQueryParams parses the http request's query parameters
+// into a translibArgs args.
+func (args *translibArgs) parseQueryParams(r *http.Request) error {
+	if strings.Contains(r.URL.Path, restconfDataPathPrefix) {
+		return args.parseRestconfQueryParams(r)
+	}
+
+	return nil
+}
+
+// parseRestconfQueryParams parses query parameters of a request 'r' to
+// fill translibArgs object 'args'. Returns httpError with status 400
+// if any parameter is unsupported or has invalid value.
+func (args *translibArgs) parseRestconfQueryParams(r *http.Request) error {
+	var err error
+	qParams := r.URL.Query()
+
+	for name, vals := range qParams {
+		switch name {
+		case "depth":
+			args.depth, err = parseDepthParam(vals, r)
+		case "deleteEmptyEntry":
+			args.deleteEmpty, err = parseDeleteEmptyEntryParam(vals, r)
+		default:
+			err = newUnsupportedParamError(name, r)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func newUnsupportedParamError(name string, r *http.Request) error {
+	return httpError(http.StatusBadRequest, "query parameter '%s' not supported", name)
+}
+
+func newInvalidParamError(name string, r *http.Request) error {
+	return httpError(http.StatusBadRequest, "invalid '%s' query parameter", name)
+}
+
+// parseDepthParam parses query parameter value for "depth" parameter.
+// See https://tools.ietf.org/html/rfc8040#section-4.8.2
+func parseDepthParam(v []string, r *http.Request) (uint, error) {
+	if !restconfCapabilities.depth {
+		glog.V(1).Infof("[%s] 'depth' support disabled", getRequestID(r))
+		return 0, newUnsupportedParamError("depth", r)
+	}
+
+	if r.Method != "GET" && r.Method != "HEAD" {
+		glog.V(1).Infof("[%s] 'depth' not supported for %s", getRequestID(r), r.Method)
+		return 0, newUnsupportedParamError("depth", r)
+	}
+
+	if len(v) != 1 {
+		glog.V(1).Infof("[%s] Expecting only 1 depth param; found %d", getRequestID(r), len(v))
+		return 0, newInvalidParamError("depth", r)
+	}
+
+	if v[0] == "unbounded" {
+		return 0, nil
+	}
+
+	d, err := strconv.ParseUint(v[0], 10, 16)
+	if err != nil || d == 0 {
+		glog.V(1).Infof("[%s] Bad depth value '%s', err=%v", getRequestID(r), v[0], err)
+		return 0, newInvalidParamError("depth", r)
+	}
+
+	return uint(d), nil
+}
+
+// parseDeleteEmptyEntryParam parses the custom "deleteEmptyEntry" query parameter.
+func parseDeleteEmptyEntryParam(v []string, r *http.Request) (bool, error) {
+	if r.Method != "DELETE" {
+		glog.V(1).Infof("[%s] deleteEmptyEntry not supported for %s", getRequestID(r), r.Method)
+		return false, newUnsupportedParamError("deleteEmptyEntry", r)
+	}
+
+	if len(v) != 1 {
+		glog.V(1).Infof("[%s] expecting only 1 deleteEmptyEntry; found %d", getRequestID(r), len(v))
+		return false, newInvalidParamError("deleteEmptyEntry", r)
+	}
+
+	return strings.EqualFold(v[0], "true"), nil
+}

--- a/rest/server/query_test.go
+++ b/rest/server/query_test.go
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2020 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func testQuery(method, queryStr string, exp *translibArgs) func(*testing.T) {
+	return func(t *testing.T) {
+		r := httptest.NewRequest(method, "/restconf/data/querytest?"+queryStr, nil)
+		_, r = GetContext(r)
+
+		p := translibArgs{}
+		err := p.parseQueryParams(r)
+
+		errCode := 0
+		if he, ok := err.(httpErrorType); ok {
+			errCode = he.status
+		}
+
+		if exp == nil && errCode == 400 {
+			return // success
+		}
+		if err != nil {
+			t.Fatalf("Failed to process query '%s'; err=%d/%v", r.URL.RawQuery, errCode, err)
+		}
+
+		// compare parsed translibArgs
+		if p.depth != exp.depth {
+			t.Errorf("'depth' mismatch; expecting %d, found %d", exp.depth, p.depth)
+		}
+		if p.deleteEmpty != exp.deleteEmpty {
+			t.Errorf("'deleteEmptyEntry' mismatch; expting %v, found %v", exp.deleteEmpty, p.deleteEmpty)
+		}
+		if t.Failed() {
+			t.Errorf("Testcase failed for query '%s'", r.URL.RawQuery)
+		}
+	}
+}
+
+func TestQuery(t *testing.T) {
+	t.Run("none", testQuery("GET", "", &translibArgs{}))
+	t.Run("unknown", testQuery("GET", "one=1", nil))
+}
+
+func TestQuery_depth(t *testing.T) {
+	rcCaps := restconfCapabilities
+	defer func() { restconfCapabilities = rcCaps }()
+
+	restconfCapabilities.depth = true
+
+	// run depth test cases for GET and HEAD
+	testDepth(t, "=unbounded", "depth=unbounded", &translibArgs{depth: 0})
+	testDepth(t, "=0", "depth=0", nil)
+	testDepth(t, "=1", "depth=1", &translibArgs{depth: 1})
+	testDepth(t, "=101", "depth=101", &translibArgs{depth: 101})
+	testDepth(t, "=65535", "depth=65535", &translibArgs{depth: 65535})
+	testDepth(t, "=65536", "depth=65536", nil)
+	testDepth(t, "=junk", "depth=junk", nil)
+	testDepth(t, "extra", "depth=1&extra=1", nil)
+	testDepth(t, "dup", "depth=1&depth=2", nil)
+
+	// check for other methods
+	t.Run("OPTIONS", testQuery("OPTIONS", "depth=1", nil))
+	t.Run("PUT", testQuery("PUT", "depth=1", nil))
+	t.Run("POST", testQuery("POST", "depth=1", nil))
+	t.Run("PATCH", testQuery("PATCH", "depth=1", nil))
+	t.Run("DELETE", testQuery("DELETE", "depth=1", nil))
+}
+
+func TestQuery_depth_disabled(t *testing.T) {
+	rcCaps := restconfCapabilities
+	defer func() { restconfCapabilities = rcCaps }()
+
+	restconfCapabilities.depth = false
+
+	testDepth(t, "100", "depth=100", nil)
+}
+
+func testDepth(t *testing.T, name, queryStr string, exp *translibArgs) {
+	t.Run("GET/"+name, testQuery("GET", queryStr, exp))
+	t.Run("HEAD/"+name, testQuery("HEAD", queryStr, exp))
+}
+
+func TestQuery_deleteEmptyEntry(t *testing.T) {
+	t.Run("=true", testQuery("DELETE", "deleteEmptyEntry=true", &translibArgs{deleteEmpty: true}))
+	t.Run("=True", testQuery("DELETE", "deleteEmptyEntry=True", &translibArgs{deleteEmpty: true}))
+	t.Run("=TRUE", testQuery("DELETE", "deleteEmptyEntry=TRUE", &translibArgs{deleteEmpty: true}))
+	t.Run("=false", testQuery("DELETE", "deleteEmptyEntry=false", &translibArgs{deleteEmpty: false}))
+	t.Run("=1", testQuery("DELETE", "deleteEmptyEntry=1", &translibArgs{deleteEmpty: false}))
+	t.Run("GET", testQuery("GET", "deleteEmptyEntry=true", nil))
+	t.Run("HEAD", testQuery("HEAD", "deleteEmptyEntry=true", nil))
+	t.Run("OPTIONS", testQuery("OPTIONS", "deleteEmptyEntry=true", nil))
+	t.Run("PUT", testQuery("PUT", "deleteEmptyEntry=true", nil))
+	t.Run("POST", testQuery("POST", "deleteEmptyEntry=true", nil))
+	t.Run("PATCH", testQuery("PATCH", "deleteEmptyEntry=true", nil))
+}


### PR DESCRIPTION
1\) Enhanced REST server to parse URL query parameters and pass them to
translib APIs. Handles RESTCONF "depth" and a custom "deleteEmptyEntry"
query parameters. The deleteEmptyEntry parameter is valid only for
DELETE requests; takes a boolean value - "true" or "false". It will be
passed to translib via SetRequest.DeleteEmptyEntry property. App modules
and transofrmer changes to handle these parameters is pending.

2\) Modified cli_client get() and head() python APIs to accept optional
depth parameter, which should be a +ve integer. By default no depth
value is passed to the server. Usage:
    cl.get(path, depth=2)
    cl.head(path, depth=1)

3\) Modified cli_client.delete python API to accept an optional
deleteEmptyEntry parameter. Default value is False. When specified as
True, the DELETE request will include "deleteEmptyEntry=true" query
parameter. Usage:
    cl.delete(path, deleteEmptyEntry=True)