### PR TITLE
Event Management support

### DIFF
--- a/CLI/actioner/sonic-cli-event.py
+++ b/CLI/actioner/sonic-cli-event.py
@@ -1,0 +1,191 @@
+###########################################################################
+#
+# Copyright 2019 Dell, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###########################################################################
+from rpipe_utils import pipestr
+import cli_client as cc
+import cli_log as log
+from scripts.render_cli import show_cli_output
+import collections
+from natsort import natsorted, ns
+
+def recent_interval(interval):
+    if interval == "5min":
+       return "5_MINUTES"
+    elif interval == "60min":
+       return "60_MINUTES"
+    elif interval == "24hr":
+       return "24_HOURS"	
+    else:
+       return "5_MINUTES"
+
+def severity(sev):
+    if sev == 'warning':
+        return "WARNING"
+    elif sev == "major":
+        return "MAJOR"
+    elif sev == "minor":
+        return "MINOR"
+    elif sev == "critical":
+        return "CRITICAL"
+    else:
+        return "INFORMATIONAL"
+
+def process_cmd_params(args):
+    filter = {}
+
+    if len(args) == 6:
+        if args[2] == "from" or args[2] == "start":
+            filter_param = {"begin":args[3],"end":args[5]}
+            if args[2] == "from":
+                filter = { "id": filter_param }
+            else:
+                filter = {"time": filter_param }
+    elif len(args) == 4:
+        if args[2] == "from" or args[2] == "start":
+            filter_param = {"begin":args[3]}
+            if args[2] == "from":
+                filter = { "id": filter_param }
+            else:
+                filter = {"time": filter_param }
+
+        elif args[2] == "severity":
+            filter = {"severity": severity(args[3])}
+
+        elif args[2] == "recent":
+            filter = {"interval": recent_interval(args[3])} 
+
+    return filter
+
+                
+def invoke_api(func, args):
+
+   api = cc.ApiClient()
+   if func == "get_alarm_all" or \
+        func == "get_alarm_detail" or \
+        func == "get_alarm_acknowledged":
+        path = "/restconf/data/sonic-alarm:sonic-alarm/ALARM/ALARM_LIST"
+        return api.get(path)
+
+   elif func == "get_alarm_filter":
+        filters = process_cmd_params(args)
+        if len(filters):
+            path = "/restconf/operations/sonic-alarm:show-alarms"
+            body  =  {"sonic-alarm:input":filters}
+            return api.post(path, body)
+        else:
+            path = "/restconf/data/sonic-alarm:sonic-alarm/ALARM/ALARM_LIST"
+            return api.get(path)
+
+   elif func == "get_alarm_id":
+        if len(args) == 4:
+            path = "/restconf/data/sonic-alarm:sonic-alarm/ALARM/ALARM_LIST=" + args[3]
+            return api.get(path)
+
+   elif func == "get_alarm_stats":
+        path = "/restconf/data/sonic-alarm:sonic-alarm/ALARM_STATS/ALARM_STATS_LIST"
+        return api.get(path)
+
+   elif func == "get_event_stats":
+        path = "/restconf/data/sonic-event:sonic-event/EVENT_STATS/EVENT_STATS_LIST"
+        return api.get(path)
+       
+   elif func == "get_event_details": 
+        path = "/restconf/data/sonic-event:sonic-event/EVENT/EVENT_LIST"
+        return api.get(path)
+
+   elif func == "get_event_filter":
+        filters = process_cmd_params(args)
+        if len(filters):
+            path = "/restconf/operations/sonic-event:show-events"
+            body  =  {"sonic-event:input":filters}
+            return api.post(path, body)
+        else:
+            path = "/restconf/data/sonic-event:sonic-event/EVENT/EVENT_LIST"
+            return api.get(path)
+
+   elif func == "get_event_id":
+        if len(args) == 4:
+            path = "/restconf/data/sonic-event:sonic-event/EVENT/EVENT_LIST=" + args[3]
+            return api.get(path)
+
+   elif func == "alarm_acknowledge":
+        if len(args) == 3:
+            body = {"sonic-alarm:input": {"id":[args[2]]}}
+            path = "/restconf/operations/sonic-alarm:acknowledge-alarms"
+            return api.post(path, body)
+
+   elif func == "alarm_unacknowledge":
+        if len(args) == 3:
+            body = {"sonic-alarm:input": {"id":[args[2]]}}
+            path = "/restconf/operations/sonic-alarm:unacknowledge-alarms"
+            return api.post(path, body)
+
+def run(func, args):
+    try:
+        api_response = invoke_api(func, args)
+        if api_response == None:
+            return
+        if api_response.ok():
+            response = api_response.content
+            if response is None:
+                print "Success"
+            else:
+                if 'sonic-event:output' in response:
+                    if response['sonic-event:output']['EVENT']['EVENT_LIST']:
+                        event_lst = natsorted(response['sonic-event:output']['EVENT']['EVENT_LIST'], key=lambda t: t["id"])
+                        response['sonic-event:output']['EVENT']['EVENT_LIST'] = event_lst 
+                        show_cli_output('show_event_summary.j2', response['sonic-event:output'])
+                elif 'sonic-event:EVENT_LIST' in response:
+                    evt_lst = natsorted(response['sonic-event:EVENT_LIST'], key=lambda t: t["id"])
+                    response['sonic-event:EVENT_LIST'] = evt_lst
+                    if func == 'get_event_details' or \
+                        func == 'get_event_id':
+                          show_cli_output('show_event_details.j2', response)
+                    else:
+                          show_cli_output('show_event_summary.j2', response)
+                elif 'sonic-alarm:output' in response:
+                    if func == 'alarm_acknowledge' or \
+                        func == 'alarm_unacknowledge':
+                        if response['sonic-alarm:output']['status']:
+                            print("Error: {}" .format(response['sonic-alarm:output']['status-detail']))
+                    else:    
+                      if response['sonic-alarm:output']['ALARM']['ALARM_LIST']:
+                        alarm_lst = natsorted(response['sonic-alarm:output']['ALARM']['ALARM_LIST'], key=lambda t: t["id"])
+                        response['sonic-alarm:output']['ALARM']['ALARM_LIST'] = alarm_lst              
+                        show_cli_output('show_event_summary.j2', response['sonic-alarm:output'])
+                elif 'sonic-alarm:ALARM_LIST' in response:
+                    if response['sonic-alarm:ALARM_LIST']:
+                        alarm_lst = natsorted(response['sonic-alarm:ALARM_LIST'], key=lambda t: t["id"])
+                        response['sonic-alarm:ALARM_LIST'] = alarm_lst              
+                        if func == 'get_alarm_detail' or \
+                            func == "get_alarm_id":
+                            show_cli_output('show_event_details.j2', response)
+                        else:
+                            show_cli_output('show_event_summary.j2', response, key=func)
+                elif 'sonic-alarm:ALARM_STATS_LIST' in response or \
+                     'sonic-event:EVENT_STATS_LIST' in response:
+                    show_cli_output('show_event_summary.j2', response)
+
+    except:
+        print("%ERROR: Transaction failure")
+
+if __name__ == '__main__':
+    log.log_info("Loading sonic_cli_event.py module")
+    pipestr().write(sys.argv)
+    func = sys.argv[1]
+
+    run(func, sys.argv[2:])

--- a/CLI/actioner/sonic-cli-evprofile.py
+++ b/CLI/actioner/sonic-cli-evprofile.py
@@ -1,0 +1,35 @@
+from collections import OrderedDict
+import sys
+import json
+from rpipe_utils import pipestr
+from scripts.render_cli import show_cli_output
+import cli_client as cc
+
+def run(func, args):
+    aa = cc.ApiClient()
+
+    if func == 'get_evprofile':
+        keypath = cc.Path('/restconf/operations/sonic-evprofile:get-evprofile')
+        response = aa.post(keypath)
+        if response.ok():
+            api_response = response.content["sonic-get-evprofile:output"]
+            show_cli_output("show_evprofile_rpc.j2", api_response)
+        else:
+            print(response.error_message())
+            return 1
+
+    if func == 'set_evprofile':
+        keypath = cc.Path('/restconf/operations/sonic-evprofile:set-evprofile')
+        body = { "sonic-evprofile:input": { "file-name": args[0]} }
+        response = aa.post(keypath, body)
+        if not response.ok():
+            print(response.error_message())
+            return 1
+
+if __name__ == '__main__':
+
+    pipestr().write(sys.argv)
+    func = sys.argv[1]
+
+    run(func, sys.argv[2:])
+

--- a/CLI/clitree/cli-xml/event.xml
+++ b/CLI/clitree/cli-xml/event.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2021 Dell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<CLISH_MODULE
+    xmlns="http://www.dellemc.com/sonic/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:schemaLocation="http://www.dellemc.com/sonic/XMLSchema
+    http://www.dellemc.com/sonic/XMLSchema/clish.xsd"
+    >
+    <!--=======================================================-->
+     <PTYPE
+        name="ALARM_SEV_TYPE"
+        method="select"
+        pattern="critical(critical) major(major) minor(minor) warning(warning) informational(informational)"
+        help=""
+        />
+     <PTYPE
+        name="EVENT_SEV_TYPE"
+        method="select"
+        pattern="critical(critical) major(major) minor(minor) warning(warning) informational(informational)"
+        help=""
+        />
+     <PTYPE
+        name="RECENT_INTERVAL"
+        method="select"
+        pattern="5min(5min) 60min(60min) 24hr(24hr)"
+        help=""
+        />
+    <!--=======================================================-->
+   <VIEW name="enable-view" >
+
+    <COMMAND
+      name="alarm"
+      help="Alarm related commands">
+    </COMMAND>
+
+    <COMMAND
+      name="alarm acknowledge"
+      help="Acknowledge an active alarm">
+      <PARAM
+        name="id"
+        ptype="STRING"
+        help="Enter id"
+        />
+       <ACTION builtin="clish_pyobj">sonic-cli-event alarm_acknowledge  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="alarm unacknowledge"
+      help="Unacknowledge an active alarm">
+      <PARAM
+        name="id"
+        ptype="STRING"
+        help="Enter id"
+        />
+       <ACTION builtin="clish_pyobj">sonic-cli-event alarm_unacknowledge  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show event"
+        help="Summary of events">
+        <PARAM
+            name="filter"
+            help="filter type"
+            mode="switch"
+            ptype="SUBCOMMAND"
+            optional="true">
+          <PARAM
+            name="from"
+            help="Set start id"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+             >
+             <PARAM
+              name="startid"
+              ptype="STRING"
+              help="Enter start id"
+              />
+              <PARAM
+                 name="to"
+                 help="Set end id"
+                 ptype="SUBCOMMAND"
+                 mode="subcommand"
+                 optional="true"
+                >
+                <PARAM
+                  name="endid"
+                  ptype="STRING"
+                  help="Enter end id"
+                  />
+              </PARAM>
+        </PARAM>
+        <PARAM
+            name="start"
+            help="Set start time"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+           >
+            <PARAM
+              name="starttime"
+              ptype="STRING"
+              help="Enter startime"
+             />
+            <PARAM
+              name="end"
+              help="Set end time"
+              mode="subcommand"
+              ptype="SUBCOMMAND"
+              optional="true"
+              >
+                <PARAM
+                  name="endtime"
+                  ptype="STRING"
+                  help="Enter endtime"
+                />
+            </PARAM>
+        </PARAM>
+      </PARAM>
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_event_filter  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show event details"
+        help="Detailed view of events">
+      <ACTION builtin="clish_pyobj">sonic-cli-event get_event_details ${__full_line} </ACTION>        
+    </COMMAND>
+
+    <COMMAND
+        name="show event id"
+        help="Display event"
+        ptype="SUBCOMMAND"
+        mode="subcommand">
+          <PARAM
+                  name="id"
+                  ptype="STRING"
+                  help="Enter event id"
+                  />
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_event_id ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+        name="show event recent"
+        help="Event recent"
+        ptype="SUBCOMMAND">
+        <PARAM
+           name="interval"
+           help="Show recent event interval"
+           ptype="RECENT_INTERVAL" />
+        <ACTION builtin="clish_pyobj">sonic-cli-event get_event_filter  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show event severity"
+        help="Display all events with a given severity"
+        ptype="SUBCOMMAND"
+        mode="subcommand">
+        <PARAM
+              name="sev"
+              ptype="EVENT_SEV_TYPE"
+              help="Enter severity"/>
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_event_filter  ${__full_line} </ACTION>   
+    </COMMAND>
+
+    <COMMAND
+        name="show event summary"
+        help="Display event summary"
+        ptype="SUBCOMMAND">
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_event_stats ${__full_line} </ACTION>
+    </COMMAND>    
+
+    <COMMAND
+        name="show alarm all"
+        help="Display all alarms"
+        ptype="SUBCOMMAND">
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_all ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show alarm acknowledged"
+        help="Display all alarms"
+        ptype="SUBCOMMAND">
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_acknowledged ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show alarm"
+        help="Summary of alarms within the specified duration">
+        <PARAM
+            name="filter"
+            help="filter type"
+            mode="switch"
+            ptype="SUBCOMMAND"
+            optional="true">
+          <PARAM
+            name="from"
+            help="Set start id"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+             >
+             <PARAM
+              name="startid"
+              ptype="STRING"
+              help="Enter start id"
+              />
+              <PARAM
+                 name="to"
+                 help="Set end id"
+                 ptype="SUBCOMMAND"
+                 mode="subcommand"
+                 optional="true"
+                >
+                <PARAM
+                  name="endid"
+                  ptype="STRING"
+                  help="Enter end id"
+                  />
+              </PARAM>
+        </PARAM>
+        <PARAM
+            name="start"
+            help="Set start time"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+           >
+            <PARAM
+              name="starttime"
+              ptype="STRING"
+              help="Enter startime"
+             />
+            <PARAM
+              name="end"
+              help="Set end time"
+              mode="subcommand"
+              ptype="SUBCOMMAND"
+              optional="true"
+              >
+                <PARAM
+                  name="endtime"
+                  ptype="STRING"
+                  help="Enter endtime"
+                />
+            </PARAM>
+        </PARAM>
+      </PARAM>
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_filter  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show alarm id"
+        help="Display alarm"
+        ptype="SUBCOMMAND"
+        mode="subcommand">
+          <PARAM
+                  name="id"
+                  ptype="STRING"
+                  help="Enter alarm id"
+                  />
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_id ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show alarm detail"
+        help="Active alarm details"
+        ptype="SUBCOMMAND">
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_detail ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+        name="show alarm recent"
+        help="Alarm recent"
+        ptype="SUBCOMMAND">
+        <PARAM
+           name="interval"
+           help="Show recent alarm interval"
+           ptype="RECENT_INTERVAL" />
+        <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_filter  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show alarm severity"
+        help="Display all alarms with a given severity"
+        ptype="SUBCOMMAND"
+        mode="subcommand">
+        <PARAM
+              name="sev"
+              ptype="ALARM_SEV_TYPE"
+              help="Enter severity"/>
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_filter  ${__full_line} </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="show alarm summary"
+        help="Display alarm summary"
+        ptype="SUBCOMMAND">
+     <ACTION builtin="clish_pyobj">sonic-cli-event get_alarm_stats ${__full_line} </ACTION>
+    </COMMAND>
+
+  </VIEW>
+</CLISH_MODULE>

--- a/CLI/clitree/cli-xml/evprofile.xml
+++ b/CLI/clitree/cli-xml/evprofile.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!--
+Copyright 2019 Dell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE CLISH_MODULE [
+]>
+
+<CLISH_MODULE xmlns="http://www.dellemc.com/sonic/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:schemaLocation="http://www.dellemc.com/sonic/XMLSchema
+                        http://www.dellemc.com/sonic/XMLSchema/clish.xsd">
+<VIEW name="enable-view">
+    <!-- show event-profile -->
+    <COMMAND
+        name="show event profile"
+        help="Display active Event Profile"
+        mode="subcommand"
+        ptype="SUBCOMMAND">
+        <ACTION builtin="clish_pyobj">     
+            sonic-cli-evprofile get_evprofile 
+        </ACTION>
+    </COMMAND>
+
+    <!-- set event-profile -->
+    <COMMAND 
+        name="event" 
+        help="Event Framework Operations" >
+    </COMMAND>
+    <COMMAND 
+        name="event profile" 
+        help="Select an event profile as active" >
+        <PARAM
+            name="filename"
+            ptype="STRING"
+            help="Enter event profile file name"
+        />
+        <ACTION builtin="clish_pyobj"> 
+            sonic-cli-evprofile set_evprofile ${filename} ${__full_line}
+        </ACTION>
+    </COMMAND>
+
+</VIEW>
+</CLISH_MODULE>
+
+
+

--- a/CLI/renderer/scripts/render_cli.py
+++ b/CLI/renderer/scripts/render_cli.py
@@ -151,6 +151,12 @@ def show_cli_output(template_file, response, continuation=False, **kwargs):
     j2_env.lstrip_blocks = True
     j2_env.rstrip_blocks = True
 
+    def datetimeformat_rfc3339(time):
+        s = datetime.datetime.fromtimestamp(int(time)//1000000000).strftime('%Y-%m-%dT%H:%M:%S')
+        return s + "." + (str(int(time)%1000000000))[0:3] + "Z"
+
+    j2_env.globals.update(datetimeformat_rfc3339=datetimeformat_rfc3339)
+
     def datetimeformat(time):
         return datetime.datetime.fromtimestamp(int(time)).strftime('%Y-%m-%d %H:%M:%S')
 

--- a/CLI/renderer/templates/show_event_details.j2
+++ b/CLI/renderer/templates/show_event_details.j2
@@ -1,0 +1,44 @@
+{% set vars = {'header' : true } %}
+
+{% if 'sonic-event:EVENT_LIST' in json_output.keys() %}
+{% for evt  in json_output['sonic-event:EVENT_LIST']  %}
+            {{- '----------------------------------------------\n'}}
+            {{- 'Event Details -' }} {{ evt['id'] }} {{'\n'}}
+            {{- '----------------------------------------------\n'}}
+            {% if 'action' in evt %}
+                 {% set  action = evt['action'] %}
+            {% else %}
+                {% set action = '-' %}
+            {% endif %}
+            {% if 'time-created' in evt %}
+                {% set time_created = evt['time-created'] %}
+            {% else %}
+                {% set time_created = "-" %}
+            {% endif %}
+            {{- 'Id:'.ljust(20) }} {{ evt['id'] }} {{ '\n'}} {{- 'Action:'.ljust(20) }} {{ action }} {{ '\n' }} {{- 'Severity:'.ljust(20) }} {{ evt['severity'] }} {{ '\n' }} {{- 'Type:'.ljust(20) }} {{ evt['type-id'] }} {{ '\n' }} {{- 'Timestamp'.ljust(20) }} {{ datetimeformat_rfc3339(time_created) }} {{ '\n'}} {{- 'Description:'.ljust(20) }} {{ evt['text'] }} {{ '\n' }} {{- 'Source:'.ljust(20) }} {{ evt['resource'] }} {{ '\n' }} {{ '\n' }}
+{% endfor %}
+{% endif %}
+
+{% if 'sonic-alarm:ALARM_LIST' in json_output.keys() %}
+{% for alarm  in json_output['sonic-alarm:ALARM_LIST']  %}
+    {% if 'time-created' in alarm %}
+       {% set time_created = alarm['time-created'] %}
+    {% else %}
+        {% set time_created = '-' %}
+    {% endif %}
+    {% if 'acknowledged' in alarm %}
+        {% set acknowledged = alarm['acknowledged'] %}
+    {% else %}
+        {% set acknowledged = '-' %}
+    {% endif %}
+    {% if 'acknowledge-time' in alarm %}
+        {% set acknowledge_time = alarm['acknowledge-time'] %}
+    {% else %}
+        {% set acknowledge_time = '-' %}
+    {% endif %}
+            {{- '----------------------------------------------\n'}}
+            {{- 'Alarm Details -' }} {{ alarm['id'] }} {{'\n'}}
+            {{- '----------------------------------------------\n'}}
+            {{- 'Id:'.ljust(20) }} {{ alarm['id'] }} {{ '\n'}} {{- 'Severity:'.ljust(20) }} {{ alarm['severity'] }} {{ '\n' }} {{- 'Type:'.ljust(20) }} {{ alarm['type-id'] }} {{ '\n' }} {{- 'Timestamp'.ljust(20) }} {{ datetimeformat_rfc3339(time_created) }} {{ '\n'}} {{- 'Description:'.ljust(20) }} {{ alarm['text'] }} {{ '\n' }} {{- 'Source:'.ljust(20) }} {{ alarm['resource'] }} {{ '\n' }} {{- 'Acknowledged:'.ljust(20) }} {{ acknowledged }} {{ '\n' }} {{- 'Acknowledged time:'.ljust(20) }} {% if acknowledge_time == '-' %} {{ '-' }} {% else %} {{ datetimeformat_rfc3339(acknowledge_time) }} {% endif %} {{ '\n' }}{{ '\n' }}
+{% endfor %}
+{% endif %}

--- a/CLI/renderer/templates/show_event_summary.j2
+++ b/CLI/renderer/templates/show_event_summary.j2
@@ -1,0 +1,121 @@
+{% set vars = {'header' : true } %}
+{% set func = '' %}
+{% if key is defined %}
+    {% set func = key %}
+{% endif %}
+
+{% macro summary_ev(evt_list) %}
+          {% for evt  in evt_list  %}
+
+             {% if vars.header %}
+              {{- '----------------------------------------------------------------------------------------------------------------------------\n'}}
+              {{- 'Id'.ljust(12)}} {{'Action'.ljust(15)}} {{'Severity'.ljust(15)}} {{'Name'.ljust(30)}} {{ 'Timestamp'.ljust(27) }} {{ 'Description'.ljust(60)}} {{'\n'}}
+              {{- '----------------------------------------------------------------------------------------------------------------------------' }}
+              {% if vars.update({'header': False}) %}{% endif %}
+            {% endif %}
+            {% if 'action' in evt %}
+	           {% set action = evt['action'] %}
+            {% else %}
+               {% set  action = '-' %}
+            {% endif %}
+            {% if 'time-created' in evt %}
+              {% set time_created = evt['time-created'] %}
+            {% else %}
+              {% set time_created = '-' %}
+            {% endif %}
+            {% if time_created == '-' %}
+            {{- evt['id'].ljust(12) }} {{ action.ljust(15) }} {{ evt['severity'].ljust(15) }} {{ evt['type-id'].ljust(30) }} {{ '-'.ljust(35) }} {{ evt['text'].ljust(50) -}}
+            {% else %}
+            {{- evt['id'].ljust(12) }} {{ action.ljust(15) }} {{ evt['severity'].ljust(15) }} {{ evt['type-id'].ljust(30) }} {{ datetimeformat_rfc3339(time_created).ljust(27) }} {{ evt['text'].ljust(50) -}}
+            {% endif %}
+          {% endfor %}
+{% endmacro %}
+
+{% macro summary_alarm(alarm_list) %}
+          {% for alarm  in alarm_list  %}
+             {% if vars.header %}
+              {{- '----------------------------------------------------------------------------------------------------------------------------\n' }}
+              {{- 'Id'.ljust(12)}} {{'Severity'.ljust(10)}} {{'Name'.ljust(30)}} {{ 'Timestamp'.ljust(27) }} {{ 'Description'.ljust(60)}} {{'\n'}}
+              {{- '----------------------------------------------------------------------------------------------------------------------------' }}
+              {% if vars.update({'header': False}) %}{% endif %}
+            {% endif %}
+            {% if 'time-created' in alarm %}
+              {% set time_created = alarm['time-created'] %}
+            {% else %}
+              {% set time_created = '-' %}
+            {% endif %}
+            {%- if 'acknowledged' in alarm %}
+              {% if alarm['acknowledged'] == True %}
+                {% if func is defined and func == "get_alarm_filter" %}
+                  {% continue %}
+                {% endif %}
+              {% else %}
+                {% if func is defined and func == "get_alarm_acknowledged" %}
+                   {% continue %}
+                 {% endif %}
+              {% endif %}
+            {% endif -%}
+            {% if time_created == '-' %}
+            {{- alarm['id'].ljust(12) }} {{ alarm['severity'].ljust(10) }} {{ alarm['type-id'].ljust(30) }} {{ '-'.ljust(35) }} {{ alarm['text'].ljust(50) }}
+            {% else %}
+            {{- alarm['id'].ljust(12) }} {{ alarm['severity'].ljust(10) }} {{ alarm['type-id'].ljust(30) }} {{ datetimeformat_rfc3339(time_created).ljust(27) }} {{ alarm['text'].ljust(50) }}
+            {% endif %}
+          {% endfor %}
+{% endmacro %}
+
+{% if 'sonic-event:EVENT_LIST' in json_output.keys() %}
+   {{ summary_ev(json_output['sonic-event:EVENT_LIST']) }}
+{% endif %}
+
+{% if 'EVENT' in json_output.keys() %}
+   {% if 'EVENT_LIST' in json_output['EVENT'] %}
+     {% if json_output['EVENT']['EVENT_LIST'] is not none %}
+       {{ summary_ev(json_output['EVENT']['EVENT_LIST']) }}
+     {% endif %}
+   {% endif %}
+{% endif %}
+
+
+{% if 'sonic-alarm:ALARM_LIST' in json_output.keys() %}
+   {{- summary_alarm(json_output['sonic-alarm:ALARM_LIST']) }}
+{% endif %}
+
+
+{% if 'ALARM' in json_output.keys() %}
+   {% if 'ALARM_LIST' in json_output['ALARM'] %}
+     {% if json_output['ALARM']['ALARM_LIST'] is not none %}
+       {{- summary_alarm(json_output['ALARM']['ALARM_LIST']) }}
+     {% endif %}
+   {% endif %}
+{% endif %}
+
+
+{% if 'sonic-alarm:ALARM_STATS_LIST' in json_output.keys() %}
+    {% for alarm  in json_output['sonic-alarm:ALARM_STATS_LIST']  %}
+        {% if alarm['id'] == 'state' %}
+            {{- 'Alarm summary\n' }}
+            {{- '---------------------------------\n' }}
+            {{- 'Total:'.ljust(30) }} {{ alarm['alarms'] }} {{ '\n' }}
+            {{- 'Critical:'.ljust(30) }} {{ alarm['critical'] }} {{ '\n' }}
+            {{- 'Major:'.ljust(30) }} {{ alarm['major'] }} {{ '\n' }}
+            {{- 'Minor:'.ljust(30) }} {{ alarm['minor'] }} {{ '\n' }}
+            {{- 'Warning:'.ljust(30) }} {{ alarm['warning'] }} {{ '\n' }}
+            {{- 'Acnowledged:'.ljust(30) }} {{ alarm['acknowledged'] }} {{ '\n' }}
+            {{- '----------------------------------\n' }}
+        {% endif %}
+    {% endfor %}
+{% endif %}
+
+{% if 'sonic-event:EVENT_STATS_LIST' in json_output.keys() %}
+    {% for evt  in json_output['sonic-event:EVENT_STATS_LIST']  %}
+        {% if evt['id'] == 'state' %}
+            {{- 'Event summary\n' }}
+            {{- '---------------------------------\n' }}
+            {{- 'Total:'.ljust(30) }} {{ evt['events'] }} {{ '\n' }}
+            {{- 'Raised:'.ljust(30) }} {{ evt['raised'] }} {{ '\n' }}
+            {{- 'Acknowledged:'.ljust(30) }} {{ evt['acked'] }} {{ '\n' }}
+            {{- 'Cleared:'.ljust(30) }} {{ evt['cleared'] }} {{ '\n' }}
+            {{- '----------------------------------\n' }}
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/CLI/renderer/templates/show_evprofile_rpc.j2
+++ b/CLI/renderer/templates/show_evprofile_rpc.j2
@@ -1,0 +1,23 @@
+{% set vars = {'filename':'-'} %}
+{% set vars = {'filelist':[]} %}
+{% if json_output %}
+{% if vars.update({'filename': json_output["file-name"]}) %} {% endif %}
+
+{% if json_output["file-list"] %}
+{% if vars.update({'filelist': json_output["file-list"]}) %} {% endif %}
+{% endif %}
+
+Active Event Profile
+--------------------------
+{{vars.filename}}
+
+
+--------------------------
+Available Event Profiles
+--------------------------
+{% for file in vars.filelist %}
+{{file}}
+{% endfor %}
+
+{% endif %}
+


### PR DESCRIPTION
Changes are done as part of Event and Alarm Framework described in [HLD](https://github.com/Azure/SONiC/pull/761)

The changes involve xml, actioner and renderer scripts to support various show/exec commands as described in the above HLD.

```
sonic# show event summary
Event summary
---------------------------------
Total:                         40000
Raised:                        14004
Acknowledged:                  7002
Cleared:                       14004
----------------------------------
sonic# show alarm summary
Alarm summary
---------------------------------
Total:                         0
Critical:                      0
Major:                         0
Minor:                         0
Warning:                       0
Acnowledged:                   0
----------------------------------
sonic# show event

----------------------------------------------------------------------------------------------------------------------------
Id           Action          Severity        Name                           Timestamp                   Description
----------------------------------------------------------------------------------------------------------------------------
2013         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:55.256Z    RAISing for unit testing
2014         ACKNOWLEDGE     WARNING         DUMMY_ALARM                    2021-06-07T04:21:55.457Z    ACKNOWLEDGing for unit testing
2015         UNACKNOWLEDGE   WARNING         DUMMY_ALARM                    2021-06-07T04:21:55.658Z    UNACKNOWLEDGing for unit testing
2016         CLEAR           WARNING         DUMMY_ALARM                    2021-06-07T04:21:55.859Z    CLEARing for unit testing
2017         -               INFORMATIONAL   CUSTOM_EVPROFILE_CHANGE        2021-06-07T04:21:55.860Z    Raised for unit testing
2018         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:56.620Z    Raised for unit testing
2019         CLEAR           WARNING         DUMMY_ALARM                    2021-06-07T04:21:56.263Z    Clearing for unit testing
2020         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:56.464Z    Raised for unit testing
2021         CLEAR           WARNING         DUMMY_ALARM                    2021-06-07T04:21:56.665Z    Clearing for unit testing
2022         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:56.867Z    RAISing for unit testing
2023         ACKNOWLEDGE     WARNING         DUMMY_ALARM                    2021-06-07T04:21:57.684Z    ACKNOWLEDGing for unit testing
2024         CLEAR           WARNING         DUMMY_ALARM                    2021-06-07T04:21:57.269Z    CLEARing for unit testing
2025         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:57.269Z    RAISing for unit testing
2026         ACKNOWLEDGE     WARNING         DUMMY_ALARM                    2021-06-07T04:21:57.471Z    ACKNOWLEDGing for unit testing
2027         UNACKNOWLEDGE   WARNING         DUMMY_ALARM                    2021-06-07T04:21:57.672Z    UNACKNOWLEDGing for unit testing
2028         CLEAR           WARNING         DUMMY_ALARM                    2021-06-07T04:21:57.873Z    CLEARing for unit testing
2029         -               INFORMATIONAL   CUSTOM_EVPROFILE_CHANGE        2021-06-07T04:21:57.874Z    Raised for unit testing
2030         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:58.756Z    Raised for unit testing
2031         CLEAR           WARNING         DUMMY_ALARM                    2021-06-07T04:21:58.276Z    Clearing for unit testing
2032         RAISE           WARNING         DUMMY_ALARM                    2021-06-07T04:21:58.477Z    Raised for unit testing
--more--qsonic# show event
  details   Detailed view of events
  from      Set start id
  id        Display event
  profile   Display active Event Profile
  recent    Event recent
  severity  Display all events with a given severity
  start     Set start time
  summary   Display event summary
  |         Pipe through a command
  <cr>

sonic# show alarm
  acknowledged  Display all alarms
  all           Display all alarms
  detail        Active alarm details
  from          Set start id
  id            Display alarm
  recent        Alarm recent
  severity      Display all alarms with a given severity
  start         Set start time
  summary       Display alarm summary
  |             Pipe through a command
  <cr>

sonic# event
  profile  Select an event profile as active

sonic# event profile default.json
sonic# alarm
  acknowledge    Acknowledge an active alarm
  unacknowledge  Unacknowledge an active alarm

sonic# 
```

Dependent PRs
[sonic-buildimage](https://github.com/Azure/sonic-buildimage/pull/7813)
[sonic-mgmt-common](https://github.com/Azure/sonic-mgmt-common/pull/48)
[sonic-swss-common](https://github.com/Azure/sonic-swss-common/pull/490)