### PR TITLE
Showtech sonic mgmt framework: Add Management Framework functionality for "show tech-support"

### DIFF
--- a/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/CLI/actioner/sonic-cli-show-techsupport.py
@@ -37,7 +37,8 @@ def run(func, args):
 
     response = api_response.content
     if ((response is None) or
-       (response['sonic-show-techsupport:output'] is None)):
+        (not ('sonic-show-techsupport:output' in response)) or
+        (response['sonic-show-techsupport:output'] is None)):
         print("%Error: Command Failure: Unknown failure type")
         return
 

--- a/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/CLI/actioner/sonic-cli-show-techsupport.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+
+import sys
+import cli_client as cc
+import re
+
+def invoke(func, args):
+    body = None
+    aa = cc.ApiClient()
+
+    # Gather tech support information into a compressed file
+    if func == 'rpc_sonic_show_techsupport_sonic_show_techsupport_info':
+        keypath = cc.Path('/restconf/operations/sonic-show-techsupport:sonic-show-techsupport-info')
+        if args is None:
+            body = {"sonic-show-techsupport:input":{"date": None}}
+        else:
+            body = {"sonic-show-techsupport:input":{"date": args[0]}}
+        return aa.post(keypath, body)
+    else:
+        print("%Error: not implemented")
+        exit(1)
+
+
+def run(func, args):
+
+    if func != 'rpc_sonic_show_techsupport_sonic_show_techsupport_info':
+        print("%Error: Show Techsupport parsing Failed: Invalid "
+              "function")
+        return
+
+    try:
+        api_response = invoke(func, args)
+
+    except:
+        print("%Error: An exception occurred while attempting to gather the "
+              "requested information via a remote procedure call. ")
+
+    response = api_response.content
+    if ((response is None) or
+       (response['sonic-show-techsupport:output'] is None)):
+        print("%Error: Command Failure: Unknown failure type")
+        return
+
+    output_msg_object = response['sonic-show-techsupport:output']
+    if ((output_msg_object['output-filename'] is None) or
+       (len(output_msg_object['output-filename']) is 0)):
+        print("%Error: Command Failure: Unknown failure type")
+        return
+
+    if not api_response.ok():
+        # Print the message for a failing return code
+        print(output_msg_object['output-filename'])
+        return
+
+    # No error code flagged: Normal case handling
+    output_message = output_msg_object['output-filename']
+    output_file_match = re.search('\/var\/.*dump.*\.gz',
+                                  output_message)
+    if output_file_match is not None:
+        output_filename = output_file_match.group()
+        print("Output stored in:  " + output_filename)
+    else:
+        # Error message with non-error return code
+        print(output_message)
+
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 3:
+	    run(sys.argv[1], sys.argv[2:])
+    else:
+            run(sys.argv[1], None)

--- a/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/CLI/actioner/sonic-cli-show-techsupport.py
@@ -36,6 +36,12 @@ def run(func, args):
               "the requested information via a remote procedure "
               "call: {}".format(err_msg))
 
+    if not api_response.ok():
+        # Print the message for a failing return code
+        print("CLI transformer error: ")
+        print("    status code: {}".format(response.status_code))
+        return
+
     response = api_response.content
     if ((response is None) or
         (not ('sonic-show-techsupport:output' in response)) or
@@ -47,14 +53,19 @@ def run(func, args):
         return
 
     output_msg_object = response['sonic-show-techsupport:output']
-    if ((output_msg_object['output-filename'] is None) or
-       (len(output_msg_object['output-filename']) is 0)):
+
+    if ((output_msg_object['output-status'] is None) or
+        (len(output_msg_object['output-status']) is 0)):
         print("%Error: Command Failure: Unknown failure type")
         return
 
-    if not api_response.ok():
-        # Print the message for a failing return code
-        print(output_msg_object['output-filename'])
+    if not (output_msg_object['output-status'] == "Success"):
+        print("%Error: {}".format(output_msg_object['output-status']))
+        return
+
+    if ((output_msg_object['output-filename'] is None) or
+        (len(output_msg_object['output-filename']) is 0)):
+        print("%Error: Command Failure: Unknown failure type")
         return
 
     # No error code flagged: Normal case handling

--- a/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/CLI/actioner/sonic-cli-show-techsupport.py
@@ -31,15 +31,19 @@ def run(func, args):
     try:
         api_response = invoke(func, args)
 
-    except:
-        print("%Error: An exception occurred while attempting to gather the "
-              "requested information via a remote procedure call. ")
+    except ValueError as err_msg:
+        print("%Error: An exception occurred while attempting to gather "
+              "the requested information via a remote procedure "
+              "call: {}".format(err_msg))
 
     response = api_response.content
     if ((response is None) or
         (not ('sonic-show-techsupport:output' in response)) or
         (response['sonic-show-techsupport:output'] is None)):
-        print("%Error: Command Failure: Unknown failure type")
+        if ('ietf-restconf:errors' in response):
+            print(response['ietf-restconf:errors']['error'][0]['error-message'])
+        else:
+            print("%Error: Command Failure: Unknown failure type")
         return
 
     output_msg_object = response['sonic-show-techsupport:output']

--- a/CLI/clitree/cli-xml/show_techsupport.xml
+++ b/CLI/clitree/cli-xml/show_techsupport.xml
@@ -49,7 +49,7 @@ limitations under the License.
             </PARAM>
         </PARAM>
         <ACTION>
-            python $SONIC_CLI_ROOT/sonic-cli-show-techsupport.py
+            python3 $SONIC_CLI_ROOT/sonic-cli-show-techsupport.py
             rpc_sonic_show_techsupport_sonic_show_techsupport_info
             ${date}
         </ACTION>

--- a/CLI/clitree/cli-xml/show_techsupport.xml
+++ b/CLI/clitree/cli-xml/show_techsupport.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2019 Dell, Inc.  
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--> 
+
+<CLISH_MODULE
+    xmlns="http://www.dellemc.com/sonic/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:schemaLocation="http://www.dellemc.com/sonic/XMLSchema
+    http://www.dellemc.com/sonic/XMLSchema/clish.xsd">
+
+<VIEW name="enable-view">
+    <COMMAND name="show tech-support" help="Collect technical support 
+                   information">
+        <PARAM
+            name="since"
+            help="Collect logs and core files since a specified date/time"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+            optional="true">
+
+            <PARAM
+                name="date"
+                help="date/time in the format:&#xA;&#xA;
+                    &quot;YYYY-MM-DDTHH:MM:SS[.ddd...]Z&quot; or&#xA;
+                    &quot;YYYY-MM-DDTHH:MM:SS[.ddd...]+hh:mm&quot; or&#xA;
+                    &quot;YYYY-MM-DDTHH:MM:SS[.ddd...]-hh:mm&quot; Where:&#xA;&#xA;
+                    YYYY = year, MM = month, DD = day,&#xA;
+                    T (required before time),&#xA;
+                    HH = hours, MM = minutes, SS = seconds,&#xA;
+                    (optional) .ddd... = decimal fraction of a second (e.g. &quot;.323&quot;)&#xA;
+                    Z indicates zero offset from local time&#xA;
+                    +/- hh:mm indicates hour:minute offset from local time"
+                ptype="STRING">
+            </PARAM>
+        </PARAM>
+        <ACTION>
+            python $SONIC_CLI_ROOT/sonic-cli-show-techsupport.py
+            rpc_sonic_show_techsupport_sonic_show_techsupport_info
+            ${date}
+        </ACTION>
+   </COMMAND>
+</VIEW>
+</CLISH_MODULE>
+
+
+
+


### PR DESCRIPTION
Provide the changes required for supporting the "show-techsupport" command via the SONiC Management Framework front end mechanisms (CLI, REST, and gNOI). The Management Framework functionality implemented by this PR improves on the the capabilities currently provided by the SONiC Click CLI interface via the "show techsupport" command by providing the following additional features:

- User-friendly "help" information describing command syntax details for CLI invocation.
- Ability to invoke the command via REST and gNOI mechanisms.

Unit test results are attached to this PR.

[unit_test_log_0607.txt](https://github.com/Azure/sonic-mgmt-framework/files/6613105/unit_test_log_0607.txt)

#### Corequisite PRs:
https://github.com/Azure/sonic-mgmt-common/pull/49

