### PR TITLE
Bugfix/klish python c extension

### DIFF
--- a/CLI/actioner/sonic_cli_mclag.py
+++ b/CLI/actioner/sonic_cli_mclag.py
@@ -351,8 +351,8 @@ def mclag_show_mclag_interface(args):
    
     else:
         #error response
-        print api_response
-        print api_response.error_message()
+        print(api_response)
+        print(api_response.error_message())
 
     return
 
@@ -406,8 +406,8 @@ def mclag_show_mclag_brief(args):
 
     else:
         #error response
-        print api_response
-        print api_response.error_message()
+        print(api_response)
+        print(api_response.error_message())
 
     return
 
@@ -425,7 +425,7 @@ def run(func, args):
             return
 
     except Exception as e:
-            print sys.exc_value
+            print(sys.exc_value)
             return
 
 

--- a/CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c
+++ b/CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c
@@ -25,8 +25,14 @@
 #include <Python.h>
 #include <stdarg.h>
 #include <malloc.h>
+#include <dlfcn.h>
 
 void pyobj_init() {
+    void *python_lib = dlopen("libpython3.11.so.1.0", RTLD_NOW | RTLD_GLOBAL);
+    if (!python_lib) {
+        fprintf(stderr, "Failed to load Python library: %s\n", dlerror());
+    }
+
     Py_Initialize();
 }
 


### PR DESCRIPTION
### Why I did it

When KLISH invokes Python actioners using `builtin="clish_pyobj"`, Python C extensions (such as `charset_normalizer` and the SSL module) fail to load due to missing Python C API symbols. This affects all commands using this invocation method, including MCLAG commands and any new implementations.

Fixes #151 

### How I did it

Modified `CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c` to load the Python shared library with RTLD_GLOBAL before initializing Python, making Python C API symbols globally available:

```
void pyobj_init() {  
    void *python_lib = dlopen("libpython3.11.so.1.0", RTLD_NOW | RTLD_GLOBAL);  
    if (!python_lib) {  
        fprintf(stderr, "Failed to load Python library: %s\n", dlerror());  
    }  
    Py_Initialize();  
}
```

I also fixed the wrong Python2 print statements from `CLI/actioner/sonic_cli_mclag.py`.

### How to verify it

1. Build SONiC VS image with the fix
2. Login to the virtual switch
3. Run `sonic-cli`
4. Execute configure terminal
5. Execute `no mclag domain 432` (command should work without "Internal error")