### PR TITLE
sonic_cli_mclag: Use valid print() syntax

### DIFF
--- a/CLI/actioner/sonic_cli_mclag.py
+++ b/CLI/actioner/sonic_cli_mclag.py
@@ -351,8 +351,8 @@ def mclag_show_mclag_interface(args):
    
     else:
         #error response
-        print api_response
-        print api_response.error_message()
+        print(api_response)
+        print(api_response.error_message())
 
     return
 
@@ -406,8 +406,8 @@ def mclag_show_mclag_brief(args):
 
     else:
         #error response
-        print api_response
-        print api_response.error_message()
+        print(api_response)
+        print(api_response.error_message())
 
     return
 
@@ -425,7 +425,7 @@ def run(func, args):
             return
 
     except Exception as e:
-            print sys.exc_value
+            print(sys.exc_value)
             return
 
 


### PR DESCRIPTION
Some old print statements were hiding in some exception handling code. Update these to use the print() function.