### PR TITLE
Fix Jinja2 template error when IPv6 is disabled on subinterface

### DIFF
--- a/CLI/renderer/templates/show_interface.j2
+++ b/CLI/renderer/templates/show_interface.j2
@@ -76,7 +76,7 @@
 	      {% if vars.update({'ipv4_src_pfx':""}) %}{% endif %}
               {% if vars.update({'mode4':"not-set"}) %}{% endif %}
             {% endif %}
-            {% if subif["openconfig-if-ip:ipv6"] %}
+            {% if subif["openconfig-if-ip:ipv6"] and "addresses" in subif["openconfig-if-ip:ipv6"] %}
               {% set ip_list = subif["openconfig-if-ip:ipv6"]["addresses"]["address"] %}
               {% set ipv6_all = [] %}
               {% for ip in ip_list %}

--- a/CLI/renderer/templates/show_interface_id.j2
+++ b/CLI/renderer/templates/show_interface_id.j2
@@ -73,7 +73,7 @@
             {% else %}
               {% if vars.update({'mode4':"not-set"}) %}{% endif %}
             {% endif %}
-            {% if subif["openconfig-if-ip:ipv6"] %}
+            {% if subif["openconfig-if-ip:ipv6"] and "addresses" in subif["openconfig-if-ip:ipv6"] %}
               {% set ip_list = subif["openconfig-if-ip:ipv6"]["addresses"]["address"] %}
               {% set ipv6_all = [] %}
               {% for ip in ip_list %}


### PR DESCRIPTION
Fix for issue sonic-net/sonic-buildimage#23323

The show_interface.j2 template throws a jinja2.exceptions.UndefinedError when IPv6 is disabled on a subinterface because it doesn't check if the 'addresses' field exists before accessing it.

When IPv6 is disabled on a subinterface, the openconfig-if-ip:ipv6 object exists but does not contain an 'addresses' field. The template was checking if the ipv6 object exists but then immediately trying to access the addresses field without verifying its existence.

This change adds a conditional check to ensure the 'addresses' field exists in the openconfig-if-ip:ipv6 object before attempting to access it.

Test scenarios:
- IPv6 disabled (no addresses field) - works without errors
- IPv6 enabled (with addresses field) - works as before