### PR TITLE
[build] Add go mod tidy before go mod vendor for Go 1.24 compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,15 @@ $(GO_MOD):
 	$(GO) mod init github.com/Azure/sonic-mgmt-framework
 
 $(GO_DEPS): $(GO_MOD) $(GO_CODEGEN_INIT)
+	@# Run go mod tidy only if installed Go >= go.mod's go directive
+	@GO_MOD_VER=$$(sed -n 's/^go //p' go.mod) && \
+	 GO_CUR_VER=$$($(GO) env GOVERSION | sed 's/go//') && \
+	 if printf '%s\n' "$$GO_MOD_VER" "$$GO_CUR_VER" | sort -V | head -1 | grep -qx "$$GO_MOD_VER"; then \
+	   echo "Running go mod tidy (Go $$GO_CUR_VER >= go.mod $$GO_MOD_VER)"; \
+	   $(GO) mod tidy; \
+	 else \
+	   echo "Skipping go mod tidy (Go $$GO_CUR_VER < go.mod $$GO_MOD_VER)"; \
+	 fi
 	$(GO) mod vendor
 	$(MGMT_COMMON_DIR)/patches/apply.sh vendor
 	touch  $@


### PR DESCRIPTION
## Description
[agent]
Add `go mod tidy` before `go mod vendor` in Makefile for Go 1.24 compatibility.

### What I did
Added `$(GO) mod tidy` before the `$(GO) mod vendor` call in the Makefile.

### Why I did it
Go 1.24 (shipped in Debian Trixie) enforces stricter module graph consistency. When `go.mod` specifies an older Go version but the build runs under Go 1.24, `go mod vendor` fails with module resolution errors unless `go mod tidy` runs first.

### How I verified it
Successfully built sonic-mgmt-framework under a Trixie slave container with Go 1.24.
On bookworm (Go 1.21), `go mod tidy` is a no-op — no behavior change.

## Type of change
- Bug fix