### PR TITLE
Debian Trixie migration for sonic-mgmt-framework

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ stages:
       vmImage: ubuntu-latest
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie:latest
 
     steps:
     - checkout: self
@@ -63,8 +63,12 @@ stages:
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(BUILD_BRANCH)'
         patterns: |
-          target/debs/bookworm/libyang*.deb
-          target/python-wheels/bookworm/sonic_yang_models*.whl
+          target/debs/trixie/libpcre3_*.deb
+          target/debs/trixie/libpcre16-3_*.deb
+          target/debs/trixie/libpcre32-3_*.deb
+          target/debs/trixie/libpcrecpp0v5_*.deb
+          target/debs/trixie/libyang*.deb
+          target/python-wheels/trixie/sonic_yang_models*.whl
       displayName: "Download sonic buildimage"
 
     - script: |
@@ -76,8 +80,14 @@ stages:
         sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
         sudo service redis-server start
 
+        # LIBPCRE3 (not in Trixie repos, required by libyang 1.0.73)
+        sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb \
+                     ../target/debs/trixie/libpcre16-3_*.deb \
+                     ../target/debs/trixie/libpcre32-3_*.deb \
+                     ../target/debs/trixie/libpcrecpp0v5_*.deb
+
         # LIBYANG
-        sudo dpkg -i ../target/debs/bookworm/libyang*1.0.73*.deb
+        sudo dpkg -i ../target/debs/trixie/libyang*1.0.73*.deb
 
         # Install from "requirement" files in sonic-mgmt-framework/tools/test directory.
         pushd sonic-mgmt-framework/tools/test
@@ -94,7 +104,7 @@ stages:
       displayName: "Install dependency"
 
     - script: |
-        sudo pip3 install ../target/python-wheels/bookworm/sonic_yang_models-1.0-py3-none-any.whl
+        sudo pip3 install ../target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl
       displayName: "Install sonic yangs"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,7 @@ stages:
       displayName: "Install dependency"
 
     - script: |
-        sudo pip3 install ../target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl
+        sudo pip3 install ../target/python-wheels/trixie/sonic_yang_models*.whl
       displayName: "Install sonic yangs"
 
     - script: |

--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,4 @@ require (
 
 replace github.com/Azure/sonic-mgmt-common => ../sonic-mgmt-common
 
-go 1.19
+go 1.24.4


### PR DESCRIPTION
#### Why I did it - 
Required for https://github.com/sonic-net/SONiC/issues/2169 

#### How I did it - 
Updated Azure Pipelines to use sonic-slave-trixie container
Added libpcre3 dependencies (not available in Trixie repos)
Bumped Go version to 1.24.4 to align with Trixie's provided version
Updated dependency paths to use Trixie-specific packages and Python wheels

#### How to verify it - 
The sonic-mgmt-framework container  builds successfully under BLDENV=trixie. Installed it on a recent SONiC image and verified that the docker os distribution shows Trixie and basic curl test on REST server hosted within the docker works fine. Also executed the pipeline tests locally.

**Note:**
Dependent/Related  PRs:
https://github.com/sonic-net/sonic-buildimage/pull/26548
https://github.com/sonic-net/sonic-mgmt-common/pull/211

