### PR TITLE
klish: stop auto-injecting exit/end when the view already declares one

### DIFF
--- a/CLI/clitree/scripts/klish_ins_def_cmd.py
+++ b/CLI/clitree/scripts/klish_ins_def_cmd.py
@@ -83,8 +83,26 @@ END_CMD = """<COMMAND name="end"
                  view="enable-view"/>"""
 
 VIEW_TAG_STR = """{http://www.dellemc.com/sonic/XMLSchema}VIEW"""
+COMMAND_TAG_STR = """{http://www.dellemc.com/sonic/XMLSchema}COMMAND"""
 ENABLE_VIEW_STR = """enable-view"""
 SKIP_VIEW_LIST = ["enable-view", "hidden-view", "ping-view"]
+
+
+def _view_has_command(view_element, command_name):
+    """Return True if the view already declares <COMMAND name="..."/>.
+
+    The auto-insert pass below adds a generic exit/end to every view
+    that hasn't been processed yet, keyed only by view name. Views that
+    legitimately ship their own exit (e.g. IOS-XR style hierarchies
+    where exit returns to the parent view rather than nesting up) end
+    up with two COMMANDs of the same name and klish refuses to parse
+    the whole file. Checking the view's own children instead is what
+    the original docstring already promises ("if exit and end command
+    are not already appended for the view")."""
+    for child in view_element:
+        if child.tag == COMMAND_TAG_STR and child.get("name") == command_name:
+            return True
+    return False
 #DBG_FLAG = False
 DBG_FLAG = True
 
@@ -106,16 +124,16 @@ def update_view_tag(root, viewlist, filename, out_dirpath):
             view_name = element_inst.get('name')
 
             if view_name not in viewlist:
-                exit_element = etree.XML(EXIT_CMD)
-                end_element = etree.XML(END_CMD)
                 inherit_enable_element = etree.XML(INHERIT_ENABLE_MODE_CMD)
                 inherit_enable_element_without_prefix = etree.XML(INHERIT_ENABLE_MODE_CMD_WITHOUT_PREFIX)
                 comment_element = etree.XML(COMMENT_NS)
 
                 if DBG_FLAG == True:
                     print("Appending to view %s ..." %view_name)
-                element_inst.insert(0,end_element)
-                element_inst.insert(0,exit_element)
+                if not _view_has_command(element_inst, "end"):
+                    element_inst.insert(0, etree.XML(END_CMD))
+                if not _view_has_command(element_inst, "exit"):
+                    element_inst.insert(0, etree.XML(EXIT_CMD))
                 element_inst.insert(0,inherit_enable_element)
 #                element_inst.insert(0,inherit_enable_element_without_prefix)
                 element_inst.insert(0,comment_element)


### PR DESCRIPTION
## Summary

\`klish_ins_def_cmd.py\` auto-inserts a generic \`<COMMAND name=\"exit\"/>\` and \`<COMMAND name=\"end\"/>\` into every VIEW that has not been processed yet. The \"already processed\" check keys on the view name across files, not on the view's own children — so any single-file VIEW that legitimately ships its own exit (e.g. IOS-XR style hierarchies where \`exit\` returns to the parent VIEW rather than nesting up) ends up with two COMMANDs of the same name. klish then refuses to load the file with:

\`\`\`
Error parsing XML: Duplicate COMMAND name=\"exit\".
Error parsing XML: Node VIEW, name=\"config-evpn-view\"
\`\`\`

When that happens during klish startup the affected view becomes unusable, and any \`clish_start\` invocation (interactive or batch) prints the parser errors to stderr before the prompt. Batch stdin (\`docker exec -i mgmt-framework /usr/sbin/cli/clish_start < cfg\`) fails outright.

The original docstring already promises this guard:

> if \"exit\" and \"end\" command are not already appended for the view, the script will append them for the view

This change makes the implementation match. We check the view's own COMMAND children for \`name=\"exit\"\` and \`name=\"end\"\` before inserting.

## Discovered

First end-to-end run of \`canonical-mpls\` (terto-horizon \`sim/canonical-mpls\`), 2026-05-12. With the EVPN, OSPF, BGP, ACL, QoS, L2VPN, MPLS-LDP and segment-routing views all shipping their own exit, the bug silently broke 21 view files (108 dup COMMANDs total) on the running \`mgmt-framework\` container.

## Test plan

- [x] On a running mgmt-framework with the buggy XMLs, applying the equivalent transform (remove every \`COMMAND name=\"exit\" lock=\"false\"\` where another COMMAND \`name=\"exit\"\` exists in the same VIEW) unblocks \`clish_start\` and lets it accept batch stdin from \`sim/canonical-mpls/configs/pe1.cfg\`.
- [ ] After this PR merges, rebuilding \`docker-sonic-mgmt-framework\` should produce XML with a single \`<COMMAND name=\"exit\"/>\` per view that originally shipped one.

## Out of scope (next PRs)

- Legacy \`CLI/clitree/cli-xml/startup.xml\` (Dell 2019) declares \`<STARTUP view=\"enable-view\">\`. The tertoos \`01-exec-view.xml\` declares \`<STARTUP view=\"exec-view\"/>\`. klish refuses to load with two STARTUPs. Needs to be deleted on the tertoos feature branch that introduces \`01-exec-view.xml\`, not on master (would break upstream-aligned branches that don't have a replacement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)