### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,9 @@ stages:
           target/debs/trixie/libpcre16-3_*.deb
           target/debs/trixie/libpcre32-3_*.deb
           target/debs/trixie/libpcrecpp0v5_*.deb
-          target/debs/trixie/libyang*.deb
+          target/debs/trixie/libyang3_*.deb
+          target/debs/trixie/libyang-dev_3*.deb
+          target/debs/trixie/python3-libyang_*.deb
           target/python-wheels/trixie/sonic_yang_models*.whl
       displayName: "Download sonic buildimage"
 
@@ -80,14 +82,16 @@ stages:
         sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
         sudo service redis-server start
 
-        # LIBPCRE3 (not in Trixie repos, required by libyang 1.0.73)
+        # LIBPCRE3 (not in Trixie repos, required by libyang3)
         sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb \
                      ../target/debs/trixie/libpcre16-3_*.deb \
                      ../target/debs/trixie/libpcre32-3_*.deb \
                      ../target/debs/trixie/libpcrecpp0v5_*.deb
 
         # LIBYANG
-        sudo dpkg -i ../target/debs/trixie/libyang*1.0.73*.deb
+        sudo dpkg -i ../target/debs/trixie/libyang3_*.deb \
+                     ../target/debs/trixie/libyang-dev_3*.deb \
+                     ../target/debs/trixie/python3-libyang_*.deb
 
         # Install from "requirement" files in sonic-mgmt-framework/tools/test directory.
         pushd sonic-mgmt-framework/tools/test


### PR DESCRIPTION
#### Why I did it
sonic-buildimage no longer builds the libyang 1.0.73 debs (`libyang`, `libyang-cpp`, `python3-yang`); it now builds only libyang3. The CI pipeline still downloads and installs the removed libyang1 debs from the sonic-buildimage build artifacts, so it must switch to the libyang3 debs.

Part of sonic-net/sonic-buildimage#22385.

#### How I did it
Updated `azure-pipelines.yml` to consume the libyang3 debs using versionless globs:
- Download/install `libyang3_*.deb` and `libyang-dev_*.deb` in place of the versioned `libyang*1.0.73*` set.
- Renamed `python3-yang_*.deb` to `python3-libyang_*.deb`.
- Dropped the removed `libyang-cpp` deb.
- Generalized the `LIBPCRE3` comment that referenced `libyang 1.0.73` to reference `libyang3`.

#### How to verify it
- Run the `azure-pipelines.yml` build and confirm the download step pulls the libyang3 debs from the sonic-buildimage artifacts and `dpkg -i` installs them without error.
- Confirm the sonic-mgmt-framework build/tests succeed with the libyang3 packages installed.

#### Description for the changelog
azure-pipelines: migrate libyang1 deb install to libyang3
