### PR TITLE
[rest]: Fix RESTCONF basic auth — rsa-sha2 host keys and FIPS-safe SSH KEX

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gorilla/mux v1.7.4
 	github.com/pkg/profile v1.7.0
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/crypto v0.24.0
 	gopkg.in/go-playground/validator.v9 v9.31.0
 )
 
@@ -32,9 +32,10 @@ require (
 	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
-	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/net v0.21.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/term v0.21.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto v0.0.0-20200319113533-08878b785e9c // indirect
 	google.golang.org/grpc v1.28.0 // indirect
 	google.golang.org/protobuf v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
+golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -123,6 +125,8 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -137,10 +141,16 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac h1:oN6lz7iLW/YC7un8pq+9bOLyXrprv2+DKfkJY+2LJJw=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.21.0 h1:WVXCp+/EBEHOj53Rvu+7KiT/iElMrO8ACK16SMZ3jaA=
+golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
+golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -185,6 +195,8 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rest/server/pamAuth.go
+++ b/rest/server/pamAuth.go
@@ -120,6 +120,15 @@ func PAMAuthenAndAuthor(r *http.Request, rc *RequestContext) error {
 			ssh.Password(passwd),
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		// In FIPS mode (sonic_fips=1) the golang-fips crypto layer rejects
+		// X25519, so the default curve25519-sha256 key exchange panics
+		// ("curve25519: internal error") inside the ssh handshake goroutine
+		// and crashes the whole process. Restrict the exchange and cipher to
+		// FIPS-approved algorithms the local sshd also offers.
+		Config: ssh.Config{
+			KeyExchanges: []string{"ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521"},
+			Ciphers:      []string{"aes128-gcm@openssh.com", "aes256-gcm@openssh.com"},
+		},
 	}
 	_, err := ssh.Dial("tcp", "127.0.0.1:22", config)
 	if err != nil {


### PR DESCRIPTION
Fixes sonic-net/sonic-buildimage#28142
RESTCONF basic auth (which dials the local sshd) is broken two ways: the pinned 2020 x/crypto has no rsa-sha2-256/512 host-key algorithms so it never matches OpenSSH ≥8.8, and once bumped the default curve25519 key exchange panics under FIPS (golang- fips rejects X25519), crashing the process. Bump x/crypto to v0.24.0 and pin the auth SSH client to FIPS-approved ECDH-P256/AES- GCM.

#### Why I did it

RESTCONF username/password (HTTP basic) authentication is broken. Basic auth is implemented by dialing the local sshd (`rest/server/pamAuth.go` does `ssh.Dial 127.0.0.1:22` because the container has no access to the host's `/etc/passwd`/`/etc/shadow`). Two problems stack on top of each other:

**1. No common host-key algorithm (all images with modern OpenSSH).**
The pinned `golang.org/x/crypto` (2020) advertises only `ssh-rsa`/`ssh-ed25519`/`ecdsa-*` host-key algorithms. OpenSSH >= 8.8 no longer offers `ssh-rsa` (SHA-1) and, with only an RSA host key present, offers `rsa-sha2-512`/`rsa-sha2-256`. There is no intersection, so the SSH handshake fails and **every** login returns 401, regardless of credentials:
```
pamAuth.go Failed to authenticate; ssh: handshake failed:
  ssh: no common algorithm for host key;
  client offered: [... ecdsa-sha2-nistp256 ssh-rsa ssh-ed25519],
  server offered: [rsa-sha2-512 rsa-sha2-256]
```
This is not FIPS-specific — it affects any image whose sshd is OpenSSH >= 8.8.

**2. Key exchange panics under FIPS (`sonic_fips=1`).**
Once the host-key issue is fixed and the handshake proceeds, `x/crypto/ssh` defaults to `curve25519-sha256` for key exchange. Under FIPS the golang-fips crypto layer rejects X25519 (the same policy that makes rest_server's own TLS refuse the X25519 curve), so the exchange panics **inside the ssh handshake goroutine**, which `net/http` cannot recover — crashing the whole `rest_server` process:
```
panic: curve25519: internal error: scalarBaseMult was not 32 bytes
  golang.org/x/crypto/ssh/handshake.go
  created by golang.org/x/crypto/ssh.newClientTransport in goroutine 13
...
WARN exited: rest-server (exit status 2; not expected)   # supervisord respawns; client sees "unexpected eof"
```

Problem 2 is exposed by fixing problem 1, so both must ship together. golang-fips crashing (rather than returning an error) on an unsupported KEX is arguably an upstream bug — tracked in #<golang-fips-issue>; this PR avoids it by constraining the exchange.

#### How I did it

Two coupled changes:

**a. Bump `golang.org/x/crypto` to v0.24.0** (`go.mod`/`go.sum`), which supports the `rsa-sha2-256`/`rsa-sha2-512` host-key algorithms. v0.24.0 is deliberately chosen to match the existing SONiC-wide pin (`sonic-gnmi` already forces `x/crypto => v0.24.0` via a replace directive), keeping the go-directive floor low for backport compatibility. Newer versions add nothing for this fix (rsa-sha2 support has been present since ~2021). Note: CVE-2024-45337 (x/crypto/ssh, fixed v0.31.0) concerns server-side `ServerConfig.PublicKeyCallback` misuse; this code is a client using password auth and does not use PublicKeyCallback, so it is not affected.

**b. Pin FIPS-approved KEX/cipher for the auth ssh client** (`rest/server/pamAuth.go`):
```go
        config := &ssh.ClientConfig{
                User:            username,
                Auth:            []ssh.AuthMethod{ssh.Password(passwd)},
                HostKeyCallback: ssh.InsecureIgnoreHostKey(),
                Config: ssh.Config{
                        KeyExchanges: []string{"ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521"},
                        Ciphers:      []string{"aes128-gcm@openssh.com", "aes256-gcm@openssh.com"},
                },
        }
```
This is a loopback connection to the local sshd, which always offers these NIST algorithms (P-256 ECDH is FIPS-mandatory), so restricting to them is safe on both FIPS and non-FIPS images and avoids the X25519 KEX entirely. AES-GCM is an AEAD, so no separate (potentially unsupported) MAC is negotiated; the RSA-SHA2 host key uses RSA verification, which symcrypt supports.

#### How to verify it

On a `sonic_fips=1` image, with a correct admin password:
```
curl -k --noproxy '*' -u admin:<correct-pw> \
  "https://<dut>/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet1" \
  -H "accept: application/yang-data+json"
```
- Before: `curl: (56) SSL_read: unexpected eof` and `docker logs mgmt-framework` shows `exited: rest-server (exit status 2)`.
- After: returns `200` with the interface data. A **wrong** password returns a clean `401`, and the process no longer crashes (no `exit status 2` in `docker logs`).

Protocol-level confirmation that the pinned algorithms handshake against the local FIPS sshd:
```
ssh -o KexAlgorithms=ecdh-sha2-nistp256 -o Ciphers=aes128-gcm@openssh.com admin@127.0.0.1 exit
# debug1: kex: algorithm: ecdh-sha2-nistp256
# debug1: kex: host key algorithm: rsa-sha2-512
# debug1: kex: cipher: aes128-gcm@openssh.com   -> reaches password auth (no X25519 panic)
```
